### PR TITLE
Splitting up the previous/next endpoints

### DIFF
--- a/src/main/java/com/flightstats/hub/channel/ChannelContentResource.java
+++ b/src/main/java/com/flightstats/hub/channel/ChannelContentResource.java
@@ -8,6 +8,7 @@ import com.flightstats.hub.dao.ChannelService;
 import com.flightstats.hub.dao.Request;
 import com.flightstats.hub.events.ContentOutput;
 import com.flightstats.hub.events.EventsService;
+import com.flightstats.hub.exception.ConflictException;
 import com.flightstats.hub.exception.ContentTooLargeException;
 import com.flightstats.hub.exception.InvalidRequestException;
 import com.flightstats.hub.metrics.ActiveTraces;
@@ -467,6 +468,8 @@ public class ChannelContentResource {
             return builder.build();
         } catch (InvalidRequestException e) {
             return Response.status(400).entity(e.getMessage()).build();
+        } catch (ConflictException e) {
+            return Response.status(409).entity(e.getMessage()).build();
         } catch (ContentTooLargeException e) {
             return Response.status(413).entity(e.getMessage()).build();
         } catch (Exception e) {

--- a/src/main/java/com/flightstats/hub/channel/ChannelContentResource.java
+++ b/src/main/java/com/flightstats/hub/channel/ChannelContentResource.java
@@ -258,22 +258,43 @@ public class ChannelContentResource {
         return builder.build();
     }
 
-    @Path("/{h}/{m}/{s}/{ms}/{hash}/{direction:[n|p].*}")
+    @Path("/{h}/{m}/{s}/{ms}/{hash}/{direction:p.*}")
     @GET
-    public Response getDirection(@PathParam("channel") String channel,
-                                 @PathParam("Y") int year,
-                                 @PathParam("M") int month,
-                                 @PathParam("D") int day,
-                                 @PathParam("h") int hour,
-                                 @PathParam("m") int minute,
-                                 @PathParam("s") int second,
-                                 @PathParam("ms") int millis,
-                                 @PathParam("hash") String hash,
-                                 @PathParam("direction") String direction,
-                                 @QueryParam("stable") @DefaultValue("true") boolean stable,
-                                 @QueryParam("tag") String tag) {
+    public Response getPrevious(@PathParam("channel") String channel,
+                                @PathParam("Y") int year,
+                                @PathParam("M") int month,
+                                @PathParam("D") int day,
+                                @PathParam("h") int hour,
+                                @PathParam("m") int minute,
+                                @PathParam("s") int second,
+                                @PathParam("ms") int millis,
+                                @PathParam("hash") String hash,
+                                @PathParam("direction") String direction,
+                                @QueryParam("stable") @DefaultValue("true") boolean stable,
+                                @QueryParam("tag") String tag) {
         ContentKey contentKey = new ContentKey(year, month, day, hour, minute, second, millis, hash);
-        boolean next = direction.startsWith("n");
+        return adjacent(channel, stable, tag, contentKey, direction.startsWith("n"));
+    }
+
+    @Path("/{h}/{m}/{s}/{ms}/{hash}/{direction:n.*}")
+    @GET
+    public Response getNext(@PathParam("channel") String channel,
+                            @PathParam("Y") int year,
+                            @PathParam("M") int month,
+                            @PathParam("D") int day,
+                            @PathParam("h") int hour,
+                            @PathParam("m") int minute,
+                            @PathParam("s") int second,
+                            @PathParam("ms") int millis,
+                            @PathParam("hash") String hash,
+                            @PathParam("direction") String direction,
+                            @QueryParam("stable") @DefaultValue("true") boolean stable,
+                            @QueryParam("tag") String tag) {
+        ContentKey contentKey = new ContentKey(year, month, day, hour, minute, second, millis, hash);
+        return adjacent(channel, stable, tag, contentKey, direction.startsWith("n"));
+    }
+
+    private Response adjacent(String channel, boolean stable, String tag, ContentKey contentKey, boolean next) {
         if (null != tag) {
             return tagContentResource.adjacent(tag, contentKey, stable, next, uriInfo);
         }
@@ -325,29 +346,57 @@ public class ChannelContentResource {
         }
     }
 
-    @Path("/{h}/{m}/{s}/{ms}/{hash}/{direction:[n|p].*}/{count}")
+    @Path("/{h}/{m}/{s}/{ms}/{hash}/{direction:p.*}/{count}")
     @GET
     @Produces({MediaType.APPLICATION_JSON, "multipart/*", "application/zip"})
-    public Response getDirectionCount(@PathParam("channel") String channel,
-                                      @PathParam("Y") int year,
-                                      @PathParam("M") int month,
-                                      @PathParam("D") int day,
-                                      @PathParam("h") int hour,
-                                      @PathParam("m") int minute,
-                                      @PathParam("s") int second,
-                                      @PathParam("ms") int millis,
-                                      @PathParam("hash") String hash,
-                                      @PathParam("direction") String direction,
-                                      @PathParam("count") int count,
-                                      @QueryParam("stable") @DefaultValue("true") boolean stable,
-                                      @QueryParam("trace") @DefaultValue("false") boolean trace,
-                                      @QueryParam("location") @DefaultValue("ALL") String location,
-                                      @QueryParam("batch") @DefaultValue("false") boolean batch,
-                                      @QueryParam("bulk") @DefaultValue("false") boolean bulk,
-                                      @QueryParam("tag") String tag,
-                                      @HeaderParam("Accept") String accept) {
+    public Response getPreviousCount(@PathParam("channel") String channel,
+                                     @PathParam("Y") int year,
+                                     @PathParam("M") int month,
+                                     @PathParam("D") int day,
+                                     @PathParam("h") int hour,
+                                     @PathParam("m") int minute,
+                                     @PathParam("s") int second,
+                                     @PathParam("ms") int millis,
+                                     @PathParam("hash") String hash,
+                                     @PathParam("direction") String direction,
+                                     @PathParam("count") int count,
+                                     @QueryParam("stable") @DefaultValue("true") boolean stable,
+                                     @QueryParam("trace") @DefaultValue("false") boolean trace,
+                                     @QueryParam("location") @DefaultValue("ALL") String location,
+                                     @QueryParam("batch") @DefaultValue("false") boolean batch,
+                                     @QueryParam("bulk") @DefaultValue("false") boolean bulk,
+                                     @QueryParam("tag") String tag,
+                                     @HeaderParam("Accept") String accept) {
         ContentKey key = new ContentKey(year, month, day, hour, minute, second, millis, hash);
-        boolean next = direction.startsWith("n");
+        return adjacentCount(channel, count, stable, trace, location, batch, bulk, tag, accept, key, direction.startsWith("n"));
+    }
+
+    @Path("/{h}/{m}/{s}/{ms}/{hash}/{direction:n.*}/{count}")
+    @GET
+    @Produces({MediaType.APPLICATION_JSON, "multipart/*", "application/zip"})
+    public Response getNextCount(@PathParam("channel") String channel,
+                                 @PathParam("Y") int year,
+                                 @PathParam("M") int month,
+                                 @PathParam("D") int day,
+                                 @PathParam("h") int hour,
+                                 @PathParam("m") int minute,
+                                 @PathParam("s") int second,
+                                 @PathParam("ms") int millis,
+                                 @PathParam("hash") String hash,
+                                 @PathParam("direction") String direction,
+                                 @PathParam("count") int count,
+                                 @QueryParam("stable") @DefaultValue("true") boolean stable,
+                                 @QueryParam("trace") @DefaultValue("false") boolean trace,
+                                 @QueryParam("location") @DefaultValue("ALL") String location,
+                                 @QueryParam("batch") @DefaultValue("false") boolean batch,
+                                 @QueryParam("bulk") @DefaultValue("false") boolean bulk,
+                                 @QueryParam("tag") String tag,
+                                 @HeaderParam("Accept") String accept) {
+        ContentKey key = new ContentKey(year, month, day, hour, minute, second, millis, hash);
+        return adjacentCount(channel, count, stable, trace, location, batch, bulk, tag, accept, key, direction.startsWith("n"));
+    }
+
+    private Response adjacentCount(String channel, int count, boolean stable, boolean trace, String location, boolean batch, boolean bulk, String tag, String accept, ContentKey key, boolean next) {
         if (null != tag) {
             return tagContentResource.adjacentCount(tag, count, stable, trace, location, next, key, bulk || batch, accept, uriInfo);
         }

--- a/src/main/java/com/flightstats/hub/channel/ChannelResource.java
+++ b/src/main/java/com/flightstats/hub/channel/ChannelResource.java
@@ -217,9 +217,9 @@ public class ChannelResource {
         try {
             logger.info("starting events for {} at {}", channel, lastEventId);
             ContentKey contentKey = new ContentKey();
-            ContentKey keyOptional = ContentKey.fromFullUrl(lastEventId);
-            if (keyOptional != null) {
-                contentKey = keyOptional;
+            ContentKey fromUrl = ContentKey.fromFullUrl(lastEventId);
+            if (fromUrl != null) {
+                contentKey = fromUrl;
             } else if (channelService.isReplicating(channel)) {
                 Optional<ContentKey> latest = channelService.getLatest(channel, true, false);
                 if (latest.isPresent()) {

--- a/src/main/java/com/flightstats/hub/channel/TagContentResource.java
+++ b/src/main/java/com/flightstats/hub/channel/TagContentResource.java
@@ -224,19 +224,36 @@ public class TagContentResource {
         return builder.build();
     }
 
-    @Path("/{Y}/{M}/{D}/{h}/{m}/{s}/{ms}/{hash}/{direction:[n|p].*}")
+    @Path("/{Y}/{M}/{D}/{h}/{m}/{s}/{ms}/{hash}/{direction:p.*}")
     @GET
-    public Response getDirection(@PathParam("tag") String tag,
-                                 @PathParam("Y") int year,
-                                 @PathParam("M") int month,
-                                 @PathParam("D") int day,
-                                 @PathParam("h") int hour,
-                                 @PathParam("m") int minute,
-                                 @PathParam("s") int second,
-                                 @PathParam("ms") int millis,
-                                 @PathParam("hash") String hash,
-                                 @PathParam("direction") String direction,
-                                 @QueryParam("stable") @DefaultValue("true") boolean stable) {
+    public Response getPrevious(@PathParam("tag") String tag,
+                                @PathParam("Y") int year,
+                                @PathParam("M") int month,
+                                @PathParam("D") int day,
+                                @PathParam("h") int hour,
+                                @PathParam("m") int minute,
+                                @PathParam("s") int second,
+                                @PathParam("ms") int millis,
+                                @PathParam("hash") String hash,
+                                @PathParam("direction") String direction,
+                                @QueryParam("stable") @DefaultValue("true") boolean stable) {
+        ContentKey contentKey = new ContentKey(year, month, day, hour, minute, second, millis, hash);
+        return adjacent(tag, contentKey, stable, direction.startsWith("n"), uriInfo);
+    }
+
+    @Path("/{Y}/{M}/{D}/{h}/{m}/{s}/{ms}/{hash}/{direction:n.*}")
+    @GET
+    public Response getNext(@PathParam("tag") String tag,
+                            @PathParam("Y") int year,
+                            @PathParam("M") int month,
+                            @PathParam("D") int day,
+                            @PathParam("h") int hour,
+                            @PathParam("m") int minute,
+                            @PathParam("s") int second,
+                            @PathParam("ms") int millis,
+                            @PathParam("hash") String hash,
+                            @PathParam("direction") String direction,
+                            @QueryParam("stable") @DefaultValue("true") boolean stable) {
         ContentKey contentKey = new ContentKey(year, month, day, hour, minute, second, millis, hash);
         return adjacent(tag, contentKey, stable, direction.startsWith("n"), uriInfo);
     }
@@ -266,26 +283,50 @@ public class TagContentResource {
         return builder.build();
     }
 
-    @Path("/{Y}/{M}/{D}/{h}/{m}/{s}/{ms}/{hash}/{direction:[n|p].*}/{count}")
+    @Path("/{Y}/{M}/{D}/{h}/{m}/{s}/{ms}/{hash}/{direction:p.*}/{count}")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getDirectionCount(@PathParam("tag") String tag,
-                                      @PathParam("Y") int year,
-                                      @PathParam("M") int month,
-                                      @PathParam("D") int day,
-                                      @PathParam("h") int hour,
-                                      @PathParam("m") int minute,
-                                      @PathParam("s") int second,
-                                      @PathParam("ms") int millis,
-                                      @PathParam("hash") String hash,
-                                      @PathParam("direction") String direction,
-                                      @PathParam("count") int count,
-                                      @QueryParam("stable") @DefaultValue("true") boolean stable,
-                                      @QueryParam("trace") @DefaultValue("false") boolean trace,
-                                      @QueryParam("batch") @DefaultValue("false") boolean batch,
-                                      @QueryParam("bulk") @DefaultValue("false") boolean bulk,
-                                      @QueryParam("location") @DefaultValue("ALL") String location,
-                                      @HeaderParam("Accept") String accept) {
+    public Response getPreviousCount(@PathParam("tag") String tag,
+                                     @PathParam("Y") int year,
+                                     @PathParam("M") int month,
+                                     @PathParam("D") int day,
+                                     @PathParam("h") int hour,
+                                     @PathParam("m") int minute,
+                                     @PathParam("s") int second,
+                                     @PathParam("ms") int millis,
+                                     @PathParam("hash") String hash,
+                                     @PathParam("direction") String direction,
+                                     @PathParam("count") int count,
+                                     @QueryParam("stable") @DefaultValue("true") boolean stable,
+                                     @QueryParam("trace") @DefaultValue("false") boolean trace,
+                                     @QueryParam("batch") @DefaultValue("false") boolean batch,
+                                     @QueryParam("bulk") @DefaultValue("false") boolean bulk,
+                                     @QueryParam("location") @DefaultValue("ALL") String location,
+                                     @HeaderParam("Accept") String accept) {
+        ContentKey key = new ContentKey(year, month, day, hour, minute, second, millis, hash);
+        return adjacentCount(tag, count, stable, trace, location, direction.startsWith("n"), key, bulk || batch, accept, uriInfo);
+    }
+
+    @Path("/{Y}/{M}/{D}/{h}/{m}/{s}/{ms}/{hash}/{direction:n.*}/{count}")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getNextCount(@PathParam("tag") String tag,
+                                 @PathParam("Y") int year,
+                                 @PathParam("M") int month,
+                                 @PathParam("D") int day,
+                                 @PathParam("h") int hour,
+                                 @PathParam("m") int minute,
+                                 @PathParam("s") int second,
+                                 @PathParam("ms") int millis,
+                                 @PathParam("hash") String hash,
+                                 @PathParam("direction") String direction,
+                                 @PathParam("count") int count,
+                                 @QueryParam("stable") @DefaultValue("true") boolean stable,
+                                 @QueryParam("trace") @DefaultValue("false") boolean trace,
+                                 @QueryParam("batch") @DefaultValue("false") boolean batch,
+                                 @QueryParam("bulk") @DefaultValue("false") boolean bulk,
+                                 @QueryParam("location") @DefaultValue("ALL") String location,
+                                 @HeaderParam("Accept") String accept) {
         ContentKey key = new ContentKey(year, month, day, hour, minute, second, millis, hash);
         return adjacentCount(tag, count, stable, trace, location, direction.startsWith("n"), key, bulk || batch, accept, uriInfo);
     }

--- a/src/main/java/com/flightstats/hub/dao/GlobalChannelService.java
+++ b/src/main/java/com/flightstats/hub/dao/GlobalChannelService.java
@@ -128,7 +128,7 @@ public class GlobalChannelService implements ChannelService {
         return primaryAndSecondary(channelName,
                 () -> localChannelService.getLatest(channelName, stable, trace),
                 () -> {
-                    ContentKey limitKey = LocalChannelService.getLatestLimit(stable);
+                    ContentKey limitKey = localChannelService.getLatestLimit(channelName, stable);
                     Optional<ContentKey> latest = spokeContentDao.getLatest(channelName, limitKey, ActiveTraces.getLocal());
                     if (latest.isPresent()) {
                         return latest;
@@ -183,6 +183,7 @@ public class GlobalChannelService implements ChannelService {
 
     @Override
     public SortedSet<ContentKey> getKeys(DirectionQuery query) {
+        query.withLiveChannel(getCachedChannelConfig(query.getChannelName()).isLive());
         return primaryAndSecondary(query.getChannelName(),
                 () -> localChannelService.getKeys(query),
                 () -> query(query, spokeContentDao.query(query)));

--- a/src/main/java/com/flightstats/hub/dao/aws/S3Config.java
+++ b/src/main/java/com/flightstats/hub/dao/aws/S3Config.java
@@ -21,10 +21,7 @@ import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
-import java.util.Random;
-import java.util.SortedSet;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 public class S3Config {
@@ -149,7 +146,15 @@ public class S3Config {
             logger.info("updateTtlDays");
             ActiveTraces.start("S3Config.updateTtlDays");
             int maxRules = HubProperties.getProperty("s3.maxRules", 1000);
-            List<BucketLifecycleConfiguration.Rule> rules = S3ConfigStrategy.apportion(configurations, new DateTime(), maxRules);
+            List<BucketLifecycleConfiguration.Rule> rules = new ArrayList<>();
+            if (maxRules == 0) {
+                rules.add(new BucketLifecycleConfiguration.Rule()
+                        .withId("OneDay")
+                        .withExpirationInDays(1)
+                        .withStatus(BucketLifecycleConfiguration.ENABLED));
+            } else {
+                rules = S3ConfigStrategy.apportion(configurations, new DateTime(), maxRules);
+            }
             logger.info("updating {} rules with ttl life cycle ", rules.size());
             logger.trace("updating {} ", rules);
 

--- a/src/main/java/com/flightstats/hub/dao/aws/S3SingleContentDao.java
+++ b/src/main/java/com/flightstats/hub/dao/aws/S3SingleContentDao.java
@@ -237,7 +237,7 @@ public class S3SingleContentDao implements ContentDao {
         logger.trace("query {}", query);
         Traces traces = ActiveTraces.getLocal();
         traces.add("S3SingleContentDao.query", query);
-        SortedSet<ContentKey> contentKeys = Collections.emptySortedSet();
+        SortedSet<ContentKey> contentKeys;
         if (query.isNext()) {
             contentKeys = next(query);
         } else {

--- a/src/main/java/com/flightstats/hub/dao/aws/S3Verifier.java
+++ b/src/main/java/com/flightstats/hub/dao/aws/S3Verifier.java
@@ -45,6 +45,7 @@ public class S3Verifier {
     private final ExecutorService queryThreadPool = Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("S3QueryThread-%d").build());
     private final ExecutorService channelThreadPool = Executors.newFixedThreadPool(10, new ThreadFactoryBuilder().setNameFormat("S3ChannelThread-%d").build());
     @Inject
+    private
     LastContentPath lastContentPath;
     @Inject
     private ChannelService channelService;

--- a/src/main/java/com/flightstats/hub/filter/DataDogRequestFilter.java
+++ b/src/main/java/com/flightstats/hub/filter/DataDogRequestFilter.java
@@ -37,7 +37,10 @@ public class DataDogRequestFilter implements ContainerRequestFilter, ContainerRe
     @Override
     public void filter(ContainerRequestContext request, ContainerResponseContext response) {
         try {
-            threadLocal.get().setResponse(response);
+            DataDogState dataDogState = threadLocal.get();
+            if (null != dataDogState) {
+                dataDogState.setResponse(response);
+            }
         } catch (Exception e) {
             logger.error("DataDog request error", e);
         }
@@ -46,6 +49,9 @@ public class DataDogRequestFilter implements ContainerRequestFilter, ContainerRe
     public static void finalStats() {
         try {
             DataDogState dataDogState = threadLocal.get();
+            if (null == dataDogState) {
+                return;
+            }
             ContainerRequestContext request = dataDogState.getRequest();
             String endpoint = getRequestTemplate(request);
             String channel = channelName(request);

--- a/src/main/java/com/flightstats/hub/filter/DataDogRequestFilter.java
+++ b/src/main/java/com/flightstats/hub/filter/DataDogRequestFilter.java
@@ -33,7 +33,6 @@ public class DataDogRequestFilter implements ContainerRequestFilter, ContainerRe
     private static final Logger logger = LoggerFactory.getLogger(DataDogRequestFilter.class);
     private final static StatsDClient statsd = DataDog.statsd;
     private static final ThreadLocal<DataDogState> threadLocal = new ThreadLocal<>();
-    private static final String INVALID_CHARACTERS = "[\\[\\]\\|]";
 
     @Override
     public void filter(ContainerRequestContext request, ContainerResponseContext response) {
@@ -102,7 +101,6 @@ public class DataDogRequestFilter implements ContainerRequestFilter, ContainerRe
         return templateList
                 .stream()
                 .map(UriTemplate::getTemplate)
-                .map(template -> template.replaceAll(INVALID_CHARACTERS, "_"))
                 .collect(Collectors.joining());
     }
 

--- a/src/main/java/com/flightstats/hub/model/ContentKey.java
+++ b/src/main/java/com/flightstats/hub/model/ContentKey.java
@@ -106,6 +106,9 @@ public class ContentKey implements ContentPath {
 
     @Override
     public int compareTo(ContentPath other) {
+        if (other == null) {
+            return 1;
+        }
         if (other instanceof ContentKey) {
             ContentKey key = (ContentKey) other;
             int diff = time.compareTo(key.getTime());

--- a/src/main/java/com/flightstats/hub/model/DirectionQuery.java
+++ b/src/main/java/com/flightstats/hub/model/DirectionQuery.java
@@ -23,6 +23,8 @@ public class DirectionQuery implements Query {
     private final boolean stable;
     @Wither
     private final long ttlDays;
+    @Wither
+    private final boolean liveChannel;
 
     public Location getLocation() {
         if (location == null) {

--- a/src/main/java/com/flightstats/hub/spoke/FileSpokeStore.java
+++ b/src/main/java/com/flightstats/hub/spoke/FileSpokeStore.java
@@ -178,7 +178,6 @@ public class FileSpokeStore {
     }
 
     public String getLatest(String channel, String limitPath) {
-        logger.trace("ttlTime = {}", ttlMinutes);
         logger.trace("latest {} {}", channel, limitPath);
         ContentKey limitKey = ContentKey.fromUrl(limitPath).get();
         return getLatest(channel, limitPath, limitKey.getTime());

--- a/src/main/java/com/flightstats/hub/spoke/RemoteSpokeStore.java
+++ b/src/main/java/com/flightstats/hub/spoke/RemoteSpokeStore.java
@@ -226,11 +226,11 @@ public class RemoteSpokeStore {
         return null;
     }
 
-    public QueryResult readTimeBucket(String channel, String timePath) throws InterruptedException {
+    QueryResult readTimeBucket(String channel, String timePath) throws InterruptedException {
         return getKeys("/internal/spoke/time/" + channel + "/" + timePath);
     }
 
-    public SortedSet<ContentKey> getNext(String channel, int count, String startKey) throws InterruptedException {
+    SortedSet<ContentKey> getNext(String channel, int count, String startKey) throws InterruptedException {
         return getKeys("/internal/spoke/next/" + channel + "/" + count + "/" + startKey).getContentKeys();
     }
 

--- a/src/main/java/com/flightstats/hub/util/TimeUtil.java
+++ b/src/main/java/com/flightstats/hub/util/TimeUtil.java
@@ -77,7 +77,7 @@ public class TimeUtil {
         return daysFormatter.parseDateTime(property);
     }
 
-    public static DateTime getEarliestTime(int ttlDays) {
+    public static DateTime getEarliestTime(long ttlDays) {
         DateTime birthDay = TimeUtil.getBirthDay();
         if (ttlDays == 0) {
             return birthDay;
@@ -95,7 +95,6 @@ public class TimeUtil {
         MINUTES(minutesFormatter, Duration.standardMinutes(1), "minute"),
         HOURS(hoursFormatter, Duration.standardHours(1), "hour"),
         DAYS(daysFormatter, Duration.standardDays(1), "day"),
-        MONTH(monthsFormatter, Duration.standardDays(1), "month"),
         MONTHS(monthsFormatter, Duration.standardDays(28), "months");
 
         private DateTimeFormatter formatter;

--- a/src/main/java/com/flightstats/hub/webhook/SingleWebhookStrategy.java
+++ b/src/main/java/com/flightstats/hub/webhook/SingleWebhookStrategy.java
@@ -9,12 +9,6 @@ import com.flightstats.hub.dao.ChannelService;
 import com.flightstats.hub.exception.NoSuchChannelException;
 import com.flightstats.hub.metrics.ActiveTraces;
 import com.flightstats.hub.model.*;
-import com.flightstats.hub.util.ChannelNameUtils;
-import com.flightstats.hub.model.ContentKey;
-import com.flightstats.hub.model.ContentPath;
-import com.flightstats.hub.model.MinutePath;
-import com.flightstats.hub.model.TimeQuery;
-import com.flightstats.hub.replication.Replicator;
 import com.flightstats.hub.util.RuntimeInterruptedException;
 import com.flightstats.hub.util.Sleeper;
 import com.flightstats.hub.util.TimeUtil;
@@ -132,7 +126,7 @@ class SingleWebhookStrategy implements WebhookStrategy {
                     if (!channelConfig.isLive()) {
                         latestStableInChannel = channelService.getLastUpdated(channel, MinutePath.NONE).getTime();
                     }
-                    TimeQuery timeQuery = queryGenerator.getQuery(latestStableInChannel);
+                    TimeQuery timeQuery = queryGenerator.getQuery(latestStableInChannel, channelConfig.isHistorical());
                     if (timeQuery != null) {
                         addKeys(channelService.queryByTime(timeQuery));
                         if (webhook.isHeartbeat() && queryGenerator.getLastQueryTime().getSecondOfMinute() == 0) {

--- a/src/main/java/com/flightstats/hub/webhook/TimedWebhookStrategy.java
+++ b/src/main/java/com/flightstats/hub/webhook/TimedWebhookStrategy.java
@@ -8,12 +8,6 @@ import com.flightstats.hub.cluster.LastContentPath;
 import com.flightstats.hub.dao.ChannelService;
 import com.flightstats.hub.metrics.ActiveTraces;
 import com.flightstats.hub.model.*;
-import com.flightstats.hub.util.ChannelNameUtils;
-import com.flightstats.hub.model.ContentKey;
-import com.flightstats.hub.model.ContentPath;
-import com.flightstats.hub.model.ContentPathKeys;
-import com.flightstats.hub.model.TimeQuery;
-import com.flightstats.hub.replication.Replicator;
 import com.flightstats.hub.util.RuntimeInterruptedException;
 import com.flightstats.hub.util.TimeUtil;
 import com.google.common.base.Optional;
@@ -75,7 +69,7 @@ class TimedWebhookStrategy implements WebhookStrategy {
     public void start(Webhook webhook, ContentPath startingPath) {
         ThreadFactory factory = new ThreadFactoryBuilder().setNameFormat(webhook.getBatch() + "-webhook-" + webhook.getName() + "-%s").build();
         executorService = Executors.newSingleThreadScheduledExecutor(factory);
-        logger.info("starting {} with offset {}", webhook, timedWebhook.getOffsetSeconds());
+        logger.info("starting {} with starting path {}", webhook, startingPath);
         executorService.scheduleAtFixedRate(new Runnable() {
 
             ContentPath lastAdded = startingPath;

--- a/src/main/java/com/flightstats/hub/webhook/Webhook.java
+++ b/src/main/java/com/flightstats/hub/webhook/Webhook.java
@@ -46,6 +46,7 @@ public class Webhook implements Comparable<Webhook>, NamedType {
     private final String batch;
     @Wither
     private final boolean heartbeat;
+    @Wither
     private final boolean paused;
     @Wither
     private final Integer ttlMinutes;

--- a/src/main/java/com/flightstats/hub/webhook/WebhookService.java
+++ b/src/main/java/com/flightstats/hub/webhook/WebhookService.java
@@ -5,6 +5,7 @@ import com.flightstats.hub.dao.ChannelService;
 import com.flightstats.hub.dao.Dao;
 import com.flightstats.hub.exception.ConflictException;
 import com.flightstats.hub.exception.NoSuchChannelException;
+import com.flightstats.hub.model.ChannelConfig;
 import com.flightstats.hub.model.ContentKey;
 import com.flightstats.hub.model.ContentPath;
 import com.google.common.base.Optional;
@@ -15,6 +16,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 
+import static com.flightstats.hub.dao.LocalChannelService.HISTORICAL_FIRST_UPDATED;
+import static com.flightstats.hub.dao.LocalChannelService.HISTORICAL_LAST_UPDATED;
 import static com.flightstats.hub.webhook.WebhookLeader.WEBHOOK_LAST_COMPLETED;
 
 public class WebhookService {
@@ -36,8 +39,21 @@ public class WebhookService {
         this.channelService = channelService;
     }
 
+    public void unPauseHistorical(ChannelConfig channel) {
+        if (!channel.isHistorical()) {
+            return;
+        }
+        logger.info("looking to unpause webhooks for historical {}", channel);
+        Collection<Webhook> webhooks = getAll();
+        for (Webhook webhook : webhooks) {
+            if (webhook.getChannelName().equals(channel.getName())) {
+                webhook = webhook.withPaused(false);
+                upsert(webhook);
+            }
+        }
+    }
+
     public Optional<Webhook> upsert(Webhook webhook) {
-        ContentPath requestKey = webhook.getStartingKey();
         webhook = webhook.withDefaults(true);
         logger.info("upsert webhook with defaults " + webhook);
         webhookValidator.validate(webhook);
@@ -52,8 +68,9 @@ public class WebhookService {
             }
         }
         ContentPath existing = lastContentPath.getOrNull(name, WEBHOOK_LAST_COMPLETED);
-        logger.info("webhook {} existing {} requestKey {}", name, existing, requestKey);
-        if (existing == null || requestKey != null) {
+        logger.info("webhook {} existing {} requestKey {}", name, existing, webhook.getStartingKey());
+        webhook = upsertHistorical(webhook, name);
+        if (existing == null || webhook.getStartingKey() != null) {
             logger.info("initializing {} {}", name, webhook.getStartingKey());
             lastContentPath.initialize(name, webhook.getStartingKey(), WEBHOOK_LAST_COMPLETED);
         }
@@ -62,11 +79,37 @@ public class WebhookService {
         return webhookOptional;
     }
 
+    private Webhook upsertHistorical(Webhook webhook, String name) {
+        try {
+            ChannelConfig channel = channelService.getCachedChannelConfig(webhook.getChannelName());
+            if (channel.isHistorical()) {
+                ContentPath first = lastContentPath.get(channel.getName(), ContentKey.NONE, HISTORICAL_FIRST_UPDATED);
+                if (first.equals(ContentKey.NONE)) {
+                    webhook = webhook.withPaused(true);
+                    webhook = webhook.withStartingKey(ContentKey.NONE);
+                    logger.info("pausing historical webhook {}", webhook);
+                } else {
+                    ContentPath lastUpdated = lastContentPath.get(channel.getName(), ContentKey.NONE, HISTORICAL_LAST_UPDATED);
+                    if (lastUpdated.equals(ContentKey.NONE)) {
+                        webhook = webhook.withStartingKey(new ContentKey(first.getTime().minusMillis(1), "initial"));
+                    } else if (webhook.getStartingKey() == null || webhook.getStartingKey().compareTo(lastUpdated) > 0) {
+                        webhook = webhook.withStartingKey(lastUpdated);
+                    }
+                    logger.info("historical webhook with data {}", webhook);
+                    lastContentPath.update(webhook.getStartingKey(), name, WEBHOOK_LAST_COMPLETED);
+                }
+            }
+        } catch (NoSuchChannelException e) {
+            logger.debug("no channel for webhook {}", webhook.getChannelName());
+        }
+        return webhook;
+    }
+
     public Optional<Webhook> get(String name) {
         return Optional.fromNullable(webhookDao.get(name));
     }
 
-    public Optional<Webhook> getCached(String name) {
+    Optional<Webhook> getCached(String name) {
         return Optional.fromNullable(webhookDao.getCached(name));
     }
 

--- a/src/main/resources/hub.properties
+++ b/src/main/resources/hub.properties
@@ -5,6 +5,8 @@ app.environment=local
 s3.environment=local
 s3.endpoint=s3-external-1.amazonaws.com
 s3.writeQueueSize=2000
+# setting s3.maxRules to zero means all the the bucket will ony have a lifecycle of a day
+s3.maxRules=0
 dynamo.table_creation_wait_minutes=10
 app.name=hub-v2
 app.lib_path=

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -26,10 +26,7 @@
     <logger name="com.sun.jersey.server.wadl.generators" level="WARN"/>
     <logger name="org.apache.zookeeper.server.PrepRequestProcessor" level="WARN"/>
     <logger name="com.flightstats.hub" level="DEBUG"/>
-
-    <logger name="com.flightstats.hub.spoke" level="TRACE"/>
+    <logger name="com.flightstats.hub.webhook" level="TRACE"/>
     <logger name="com.flightstats.hub.filter.TracesFilter" level="TRACE"/>
-    <logger name="com.flightstats.hub.filter.DataDogRequestFilter" level="TRACE"/>
-
 
 </configuration>

--- a/src/test/continuous/verify_locust_spec.js
+++ b/src/test/continuous/verify_locust_spec.js
@@ -6,6 +6,7 @@ var locustUrl = process.env.locustUrl;
 locustUrl = 'http://' + locustUrl + '/stats/';
 console.log(locustUrl);
 
+var timeout = 60 * 1000;
 /**
  * This should get the results from a running locust install and logs results to the console
  * http://locustUrl/stats/requests
@@ -32,7 +33,7 @@ describe(testName, function () {
                 });
                 done();
             })
-    });
+    }, timeout);
 
     it('resets stats', function (done) {
         var url = locustUrl + 'reset';
@@ -45,6 +46,6 @@ describe(testName, function () {
                 expect(res.status).toBe(200);
                 done();
             })
-    });
+    }, timeout);
 
 });

--- a/src/test/integration/historical_order_spec.js
+++ b/src/test/integration/historical_order_spec.js
@@ -1,0 +1,27 @@
+require('./integration_config.js');
+
+var request = require('request');
+var http = require('http');
+var parse = require('parse-link-header');
+var channel = utils.randomChannelName();
+var moment = require('moment');
+
+var testName = __filename;
+var channelBody = {
+    historical: true,
+    ttlDays: 365
+};
+/**
+ * This should:
+ * Create a historical channel
+ * Add an item
+ * Add an item before the first
+ */
+describe(testName, function () {
+
+    utils.putChannel(channel, false, channelBody, testName);
+    var channelUrl = hubUrlBase + '/channel/' + channel + '/';
+    utils.addItem(channelUrl + '2016/06/01/12/00/00/000', 201);
+    utils.addItem(channelUrl + '2016/06/01/11/00/00/000', 409);
+
+});

--- a/src/test/java/com/flightstats/hub/dao/ContentDaoUtil.java
+++ b/src/test/java/com/flightstats/hub/dao/ContentDaoUtil.java
@@ -228,6 +228,7 @@ public class ContentDaoUtil {
                 .next(next)
                 .contentKey(new ContentKey(queryTime, "0"))
                 .ttlDays(120)
+                .liveChannel(true)
                 .build();
         Collection<ContentKey> found = contentDao.query(query);
         logger.info("query {} {}", queryTime, found);

--- a/src/test/load/global.py
+++ b/src/test/load/global.py
@@ -45,6 +45,7 @@ fh.setFormatter(formatter)
 logger.addHandler(fh)
 
 groupCallbacks = {}
+groupCallbackLocks = {}
 groupConfig = {}
 
 print globalConfig.globalConfig
@@ -106,12 +107,14 @@ class WebsiteTasks(TaskSet):
 
         groupCallbacks[self.channel] = {
             "data": [],
-            "lock": threading.Lock(),
             "parallel": parallel,
             "batch": batch,
             "heartbeat": heartbeat,
             "heartbeats": [],
             "firstTime": True
+        }
+        groupCallbackLocks[self.channel] = {
+            "lock": threading.Lock(),
         }
         group = {
             "callbackUrl": "http://" + groupConfig['ip'] + ":8089/callback/" + self.channel,
@@ -160,11 +163,11 @@ class WebsiteTasks(TaskSet):
     def append_href(self, href, obj):
         shortHref = WebsiteTasks.getUrlAfterChannel(href)
         try:
-            obj[self.channel]["lock"].acquire()
+            groupCallbackLocks[self.channel]["lock"].acquire()
             obj[self.channel]["data"].append(shortHref)
             logger.debug('wrote %s', shortHref)
         finally:
-            obj[self.channel]["lock"].release()
+            groupCallbackLocks[self.channel]["lock"].release()
 
     def read(self, uri):
         with self.client.get(uri, catch_response=True, name="get_payload") as postResponse:
@@ -287,13 +290,13 @@ class WebsiteTasks(TaskSet):
         return ''.join(random.choice(chars) for x in range(size))
 
     def verify_callback(self, obj, name="group"):
-        obj[self.channel]["lock"].acquire()
+        groupCallbackLocks[self.channel]["lock"].acquire()
         items = len(obj[self.channel]["data"])
         if items > 500:
             events.request_failure.fire(request_type=name, name="length", response_time=1,
                                         exception=-1)
             logger.info(name + " too many items in " + self.channel + " " + str(items))
-        obj[self.channel]["lock"].release()
+        groupCallbackLocks[self.channel]["lock"].release()
 
     @task(10)
     def verify_callback_length(self):
@@ -332,11 +335,14 @@ class WebsiteTasks(TaskSet):
             events.request_failure.fire(request_type="group", name="parallel", response_time=1,
                                         exception=-1)
 
+    @web.app.route("/callback", methods=['GET'])
+    def get_channels():
+        return jsonify(items=groupCallbacks)
+
     @web.app.route("/callback/<channel>", methods=['GET', 'POST'])
     def callback(channel):
-        if request.method == "POST":
+        if request.method == 'POST':
             incoming_json = request.get_json()
-            # logger.info("incoming_json " + str(incoming_json))
             if "item" in incoming_json['type']:
                 for incoming_uri in incoming_json["uris"]:
                     # this could also handle the initial items from the first minute of the test.
@@ -345,13 +351,13 @@ class WebsiteTasks(TaskSet):
                         return "ok"
                     try:
                         shortHref = WebsiteTasks.getUrlAfterChannel(incoming_uri)
-                        groupCallbacks[channel]["lock"].acquire()
+                        groupCallbackLocks[channel]["lock"].acquire()
                         if groupCallbacks[channel]["parallel"] == 1:
                             WebsiteTasks.verify_ordered(channel, shortHref, groupCallbacks, "group")
                         else:
                             WebsiteTasks.verify_parallel(channel, shortHref)
                     finally:
-                        groupCallbacks[channel]["lock"].release()
+                        groupCallbackLocks[channel]["lock"].release()
             if incoming_json['type'] == "heartbeat":
                 logger.info("heartbeat " + str(incoming_json))
                 heartbeats = groupCallbacks[channel]["heartbeats"]
@@ -364,6 +370,11 @@ class WebsiteTasks(TaskSet):
                     else:
                         if groupCallbacks[channel]["firstTime"]:
                             groupCallbacks[channel]["firstTime"] = False
+                        elif incoming_json['id'] != groupCallbacks[channel]["lastHeartbeat"]:
+                            logger.info("heartbeat order question. id = " + incoming_json['id'] + " array=" + str(
+                                groupCallbacks[channel]["heartbeats"]))
+                            events.request_success.fire(request_type="heartbeats", name="order", response_time=1,
+                                                        response_length=1)
                         else:
                             logger.info("heartbeat order failure. id = " + incoming_json['id']
                                         + " array=" + str(heartbeats))
@@ -371,6 +382,7 @@ class WebsiteTasks(TaskSet):
                                                         exception=-1)
                 else:
                     logger.info("no heartbeat found. id = " + incoming_json['id'] + " " + channel)
+                groupCallbacks[channel]["lastHeartbeat"] = incoming_json['id']
             return "ok"
         else:
             return jsonify(items=groupCallbacks[channel]["data"])
@@ -386,5 +398,4 @@ class WebsiteUser(HttpLocust):
         groupConfig['host'] = self.host
         groupConfig['ip'] = socket.gethostbyname(socket.getfqdn())
         logger.info('groupConfig %s', groupConfig)
-        # todo look at using --logfile from https://github.com/locustio/locust/blob/master/locust/main.py#L169
         print groupConfig

--- a/src/test/load/historical.py
+++ b/src/test/load/historical.py
@@ -1,7 +1,6 @@
 # locust.py
-
-import time
-from locust import HttpLocust, TaskSet, task
+from datetime import datetime, timedelta
+from locust import HttpLocust, TaskSet, task, web
 
 from hubTasks import HubTasks
 from hubUser import HubUser
@@ -11,73 +10,96 @@ class HistoricalUser(HubUser):
     def name(self):
         return "historical_test_"
 
-    def channel_payload(self, payload):
+    def start_channel(self, payload, tasks):
         payload["historical"] = "true"
+        tasks.client.delete("/channel/" + payload['name'], name="channelDelete")
+        if tasks.number == 3:
+            payload["storage"] = "BATCH"
 
+    def channel_post_url(self, channel):
+        return "/channel/" + channel + "/" + self.historical_time("%Y/%m/%d/%H/%M/%S/%f")
+
+    def has_webhook(self):
+        return True
+
+    def has_websocket(self):
+        return False
+
+    def time_path(self, unit="second"):
+        if unit == "hour":
+            return self.historical_time("/%Y/%m/%d/%H")
+        if unit == "minute":
+            return self.historical_time("/%Y/%m/%d/%H/%M")
+        if unit == "second":
+            return self.historical_time("/%Y/%m/%d/%H/%M/%S")
+
+    def historical_time(self, time_format):
+        return (datetime.utcnow() - timedelta(days=1)).strftime(time_format)[:-3]
+
+    def start_webhook(self, config):
+        # First - posts to channel, single webhook on channel
+        # Second  - posts to channel, MINUTE webhook on channel
+        if config['number'] == 2:
+            config['batch'] = "MINUTE"
+            config['heartbeat'] = True
 
 class HistoricalTasks(TaskSet):
     hubTasks = None
 
     def on_start(self):
-        self.hubTasks = HubTasks(HistoricalUser(), self.client)
-        self.hubTasks.on_start()
-        # self.hubTasks.start_websocket()
-        # self.hubTasks.start_group_callback()
-        time.sleep(5)
+        self.user = HistoricalUser()
+        self.hubTasks = HubTasks(self.user, self.client)
+        self.hubTasks.start()
 
     @task(1000)
     def write_read(self):
         self.hubTasks.write_read()
 
-        # @task(10)
-        # def change_parallel(self):
-        #     self.hubTasks.change_parallel()
-        #
-        # @task(100)
-        # def sequential(self):
-        #     self.hubTasks.sequential()
-        #
-        # @task(1)
-        # def hour_query(self):
-        #     self.hubTasks.hour_query()
-        #
-        # @task(1)
-        # def hour_query_get_items(self):
-        #     self.hubTasks.hour_query_get_items()
-        #
-        # @task(1)
-        # def minute_query(self):
-        #     self.hubTasks.minute_query()
-        #
-        # @task(1)
-        # def minute_query_get_items(self):
-        #     self.hubTasks.minute_query_get_items()
-        #
-        # @task(10)
-        # def next_previous(self):
-        #     self.hubTasks.next_previous()
-        #
-        # @task(10)
-        # def second_query(self):
-        #     self.hubTasks.second_query()
-        #
-        # @task(10)
-        # def verify_callback_length(self):
-        #     self.hubTasks.verify_callback_length()
-        #
-        # @web.app.route("/callback", methods=['GET'])
-        # def get_channels():
-        #     return HubTasks.get_channels()
-        #
-        # @web.app.route("/callback/<channel>", methods=['GET', 'POST'])
-        # def callback(channel):
-        #     return HubTasks.callback(channel)
+    @task(1)
+    def change_parallel(self):
+        self.hubTasks.change_parallel()
+
+    @task(1)
+    def hour_query(self):
+        self.hubTasks.hour_query()
+
+    @task(1)
+    def hour_query_get_items(self):
+        self.hubTasks.hour_query_get_items()
+
+    @task(1)
+    def minute_query(self):
+        self.hubTasks.minute_query()
+
+    @task(1)
+    def minute_query_get_items(self):
+        self.hubTasks.minute_query_get_items()
+
+    @task(10)
+    def second_query(self):
+        self.hubTasks.second_query()
+
+    @task(10)
+    def next_previous(self):
+        self.hubTasks.next_previous()
+
+    @task(10)
+    def verify_callback_length(self):
+        self.hubTasks.verify_callback_length()
+
+    @web.app.route("/callback", methods=['GET'])
+    def get_channels():
+        return HubTasks.get_channels()
+
+    @web.app.route("/callback/<channel>", methods=['GET', 'POST'])
+    def callback(channel):
+        return HubTasks.callback(channel)
 
 
 class WebsiteUser(HttpLocust):
     task_set = HistoricalTasks
-    min_wait = 500
-    max_wait = 5000
+    min_wait = 50
+    max_wait = 6000
 
     def __init__(self):
         super(WebsiteUser, self).__init__()

--- a/src/test/load/hubUser.py
+++ b/src/test/load/hubUser.py
@@ -5,5 +5,20 @@ class HubUser:
     def name(self):
         raise NotImplementedError("HubUser.name must be implemented")
 
-    def channel_payload(self, payload):
+    def start_channel(self, payload, tasks):
+        pass
+
+    def channel_post_url(self, channel):
+        return "/channel/" + channel
+
+    def has_webhook(self):
+        return True
+
+    def has_websocket(self):
+        return True
+
+    def time_path(self, unit="second"):
+        return "/time/" + unit + "?stable=false"
+
+    def start_webhook(self, config):
         pass

--- a/src/test/load/setup.sh
+++ b/src/test/load/setup.sh
@@ -10,6 +10,6 @@ sudo apt-get install python-dev
 wget https://bootstrap.pypa.io/get-pip.py
 sudo python get-pip.py
 sudo pip install locustio --upgrade
-sudo pip install websocket-client
+sudo pip install websocket-client --upgrade
 sudo pip install httplib2
 


### PR DESCRIPTION
This takes the burden off the DataDog request filter and instead uses two explicit endpoints for previous and next.