### PR TITLE
mostly added in 80/8080 into if statement for shutdown curl command.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,15 +2,14 @@ FROM java:8
 
 RUN apt-get update && apt-get install -y bash ntp curl
 
-ADD run /opt/hub/bin/run
+RUN mkdir -p /mnt/log && \
+    mkdir -p /mnt/spoke
 
 ADD hub /opt/hub
 
+ADD run /opt/hub/bin/run
+
 ADD logback.xml /etc/hub/logback.xml
-
-RUN chmod +x /opt/hub/bin/*
-
-RUN mkdir -p /mnt/log && mkdir -p /mnt/spoke
 
 # singleHubMain uses 80, hubMain uses 8080 and is assumed to be behind a load-balancer
 # 3333 is the debug port and 8888 is the jmx remote port.
@@ -18,6 +17,6 @@ EXPOSE 80 8080 3333 8888
 
 ENTRYPOINT ["/bin/bash", "/opt/hub/bin/run"]
 
-# In the runfile: App, Java Main Class, Min heap, Max heap, Min new size.
+# In the runfile: Java Main Class, Min heap, Max heap, Min new size.
 # Loads singleHubMain by default, and we start with modest memory settings.
-CMD ["hub", "com.flightstats.hub.app.SingleHubMain", "256m", "512m", "10m"]
+CMD ["com.flightstats.hub.app.SingleHubMain", "256m", "512m", "10m"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -44,10 +44,10 @@ This is also demonstrated in the example docker-compose.yml file in this dir.
 
 We use a runfile to set some JVM memory settings and determine what mode the hub will run in.
 The override-able CMD in the dockerfile
-is comprised of the following five variables: App Name, Java Class, Min Heap, Max Heap, and Min New Size.
+is comprised of the following four variables: Java Class, Min Heap, Max Heap, and Min New Size.
 
 ```
-"hub", "com.flightstats.hub.app.SingleHubMain", "256m", "512m", "10m"
+"com.flightstats.hub.app.SingleHubMain", "256m", "512m", "10m"
 ```
 
 "com.flightstats.hub.app.SingleHubMain" is the single, local version of the hub and "com.flightstats.hub.app.HubMain" is the

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,9 +4,14 @@ version: '2'
 services:
   hub:
     build: .
-    command: hub com.flightstats.hub.app.HubMain 1g 2g 100m
+    command: com.flightstats.hub.app.HubMain 1g 2g 100m
     volumes:
       - /mnt/log:/mnt/log
       - /mnt/spoke:/mnt/spoke
       - /etc/hub:/etc/hub
     network_mode: "host"
+    logging:
+      driver: json-file
+      options:
+        max-size: "2g"
+        max-file: "2"

--- a/docker/run
+++ b/docker/run
@@ -5,7 +5,7 @@
 set -e
 set -x
 
-if [[ -z $1 || -z $2 ]]; then
+if [[ -z $1 ]]; then
   echo "Must specify main java class e.g. com.flightstats.hub.app.SingleHubMain"
   exit 2
 fi
@@ -13,18 +13,20 @@ fi
 # Determine deploy dir and chdir to that directory,
 # then source the config to get user info
 #
-APP=${1}
+APP=hub
 APP_HOME=/opt/$APP
 CONF_DIR=/etc/$APP
+HUB_PORT=80
 DEBUG_PORT=3333
 JMXREMOTE_PORT=8888
-MAIN_CLASS=${2}
-MIN_HEAP=${3:-256m}
-MAX_HEAP=${4:-512m}
-MIN_NEW=${5:-10m}
+MAIN_CLASS=${1}
+MIN_HEAP=${2:-256m}
+MAX_HEAP=${3:-512m}
+MIN_NEW=${4:-10m}
 
 if [[ $MAIN_CLASS == "com.flightstats.hub.app.HubMain" ]]; then
   CONFIG="${CONF_DIR}/${APP}.properties"
+  HUB_PORT=8080
 else
   CONFIG=""
 fi
@@ -54,7 +56,7 @@ JAVA_OPTS="
  -Xloggc:/mnt/log/gc.log-$(date -u '+%Y-%m-%d-%H-%M-%S')
  -Dfile.encoding=UTF-8
  -Dapp.url=http://localhost/
- -Dhttp.bind_port=80
+ -Dhttp.bind_port=${HUB_PORT}
  -Dalert.run=true
  -Dapp.stable_seconds=2
  -Ddata_dog.enable=false
@@ -72,7 +74,9 @@ function shutdownChild()
         fi
 
         kill -QUIT $CHILDPID
-        curl -i -X POST http://localhost/shutdown
+
+        echo issuing shutdown curl command...
+        curl -is -X POST http://localhost:${HUB_PORT}/shutdown
 
         kill -TERM $CHILDPID
         echo signal sent, waiting ...


### PR DESCRIPTION
* add a line into if statement to use port 8080 for curl command(s) in the script
namely to shutdown the hub gracefully (jvm and remove from LB)
* remove "APP" as an input variable because this is just a hub script. simplify.
* change readme and docker-compose and Dockerfile CMD to reflect one less variable
* slightly re-arrange Dockerfile. My logic is to order the steps from least to most-likely to change, thus cache can be used for the earlier steps more often.
Also, since we are running the script with bash, i removed the executable part.