### PR TITLE
bumping sleep time

### DIFF
--- a/src/test/integration/latest_item_in_channel_spec.js
+++ b/src/test/integration/latest_item_in_channel_spec.js
@@ -63,7 +63,7 @@ describe(testName, function () {
             });
     });
 
-    utils.sleep(5000);
+    utils.sleep(6000);
     utils.addItem(channelResource, 201);
 
     it("gets latest stable in channel ", function (done) {


### PR DESCRIPTION
This started causing an issue in one of our dev environments.
The sleep value needs to be a full second more than `app.stable_seconds`, which defaults to 5.