### PR TITLE
Improved integration test output

### DIFF
--- a/src/test/integration/ddt_reporter.js
+++ b/src/test/integration/ddt_reporter.js
@@ -12,23 +12,21 @@ const ANSI = {
     WHITE: '\u001b[37m'
 };
 
-module.exports = function (config) {
+module.exports = {
 
-    this.callback = config.onComplete || false;
+    passed: 0,
+    failed: 0,
+    disabled: 0,
 
-    this.passed = 0;
-    this.failed = 0;
-    this.disabled = 0;
-
-    this.reportRunnerStarting = function (info) {
+    reportRunnerStarting: function (info) {
         console.log('\n' + ANSI.BOLD + ANSI.MAGENTA + 'Executing tests...' + ANSI.OFF);
-    };
+    },
 
-    this.reportSpecStarting = function (info) {
+    reportSpecStarting: function (info) {
         console.log('\n' + ANSI.BOLD + '> ' + ANSI.BLUE + info.description + ANSI.OFF);
-    };
+    },
 
-    this.reportSpecResults = function (info) {
+    reportSpecResults: function (info) {
         var results = info.results();
         var status;
         if (results.skipped) {
@@ -43,12 +41,12 @@ module.exports = function (config) {
 
             case 'PASSED':
                 console.log(ANSI.BOLD + '< ' + ANSI.GREEN + status + ANSI.OFF);
-                reporter.passed++;
+                this.passed++;
                 break;
 
             case 'FAILED':
                 console.log(ANSI.BOLD + '< ' + ANSI.RED + status + ANSI.OFF);
-                reporter.failed++;
+                this.failed++;
                 results.items_.forEach(function (item) {
                     if (!item.passed_) {
                         console.log(ANSI.RED + item.trace.stack + ANSI.OFF);
@@ -57,26 +55,26 @@ module.exports = function (config) {
                 break;
 
             case 'DISABLED':
-                reporter.disabled++;
+                this.disabled++;
                 console.log(ANSI.BOLD + '< ' + ANSI.YELLOW + status + ANSI.OFF);
                 break;
 
             default:
                 console.log(ANSI.BOLD + '< ' + ANSI.CYAN + status + ANSI.OFF);
         }
-    };
+    },
 
-    this.reportSuiteResults = function (info) {
+    reportSuiteResults: function (info) {
         // don't output anything
-    };
+    },
 
-    this.reportRunnerResults = function (runner) {
+    reportRunnerResults: function (runner) {
         console.log('\n' + new Array(50).join('-') + '\n');
-        console.log(ANSI.GREEN + 'PASSED: ' + ANSI.BOLD + reporter.passed + ANSI.OFF);
-        console.log(ANSI.RED + 'FAILED: ' + ANSI.BOLD + reporter.failed + ANSI.OFF);
-        console.log(ANSI.YELLOW + 'DISABLED: ' + ANSI.BOLD + reporter.disabled + ANSI.OFF);
+        console.log(ANSI.GREEN + 'PASSED: ' + ANSI.BOLD + this.passed + ANSI.OFF);
+        console.log(ANSI.RED + 'FAILED: ' + ANSI.BOLD + this.failed + ANSI.OFF);
+        console.log(ANSI.YELLOW + 'DISABLED: ' + ANSI.BOLD + this.disabled + ANSI.OFF);
 
-        if (this.callback) this.callback(runner);
-    };
+        process.exit(this.failed ? 1 : 0);
+    }
 
 };

--- a/src/test/integration/ddt_reporter.js
+++ b/src/test/integration/ddt_reporter.js
@@ -12,23 +12,23 @@ const ANSI = {
     WHITE: '\u001b[37m'
 };
 
-const reporter = {
+module.exports = function (config) {
 
-    finished: false,
+    this.callback = config.onComplete || false;
 
-    passed: 0,
-    failed: 0,
-    disabled: 0,
+    this.passed = 0;
+    this.failed = 0;
+    this.disabled = 0;
 
-    reportRunnerStarting: function (info) {
+    this.reportRunnerStarting = function (info) {
         console.log('\n' + ANSI.BOLD + ANSI.MAGENTA + 'Executing tests...' + ANSI.OFF);
-    },
+    };
 
-    reportSpecStarting: function (info) {
+    this.reportSpecStarting = function (info) {
         console.log('\n' + ANSI.BOLD + '> ' + ANSI.BLUE + info.description + ANSI.OFF);
-    },
+    };
 
-    reportSpecResults: function (info) {
+    this.reportSpecResults = function (info) {
         var results = info.results();
         var status;
         if (results.skipped) {
@@ -64,21 +64,19 @@ const reporter = {
             default:
                 console.log(ANSI.BOLD + '< ' + ANSI.CYAN + status + ANSI.OFF);
         }
-    },
+    };
 
-    reportSuiteResults: function (info) {
+    this.reportSuiteResults = function (info) {
         // don't output anything
-    },
+    };
 
-    reportRunnerResults: function (info) {
+    this.reportRunnerResults = function (runner) {
         console.log('\n' + new Array(50).join('-') + '\n');
         console.log(ANSI.GREEN + 'PASSED: ' + ANSI.BOLD + reporter.passed + ANSI.OFF);
         console.log(ANSI.RED + 'FAILED: ' + ANSI.BOLD + reporter.failed + ANSI.OFF);
         console.log(ANSI.YELLOW + 'DISABLED: ' + ANSI.BOLD + reporter.disabled + ANSI.OFF);
 
-        this.finished = true;
-    }
+        if (this.callback) this.callback(runner);
+    };
 
 };
-
-module.exports = reporter;

--- a/src/test/integration/ddt_reporter.js
+++ b/src/test/integration/ddt_reporter.js
@@ -29,7 +29,7 @@ module.exports = {
                 .replace('\t', '')
                 .replace('\n', ''));
         } else {
-            console.log(ANSI.BOLD + '> ' + ANSI.BLUE + info.description + ANSI.OFF);
+            console.log('\n' + ANSI.BOLD + '> ' + ANSI.BLUE + info.description + ANSI.OFF);
         }
     },
 

--- a/src/test/integration/ddt_reporter.js
+++ b/src/test/integration/ddt_reporter.js
@@ -14,6 +14,8 @@ const ANSI = {
 
 const reporter = {
 
+    finished: false,
+
     passed: 0,
     failed: 0,
     disabled: 0,
@@ -73,6 +75,8 @@ const reporter = {
         console.log(ANSI.GREEN + 'PASSED: ' + ANSI.BOLD + reporter.passed + ANSI.OFF);
         console.log(ANSI.RED + 'FAILED: ' + ANSI.BOLD + reporter.failed + ANSI.OFF);
         console.log(ANSI.YELLOW + 'DISABLED: ' + ANSI.BOLD + reporter.disabled + ANSI.OFF);
+
+        this.finished = true;
     }
 
 };

--- a/src/test/integration/ddt_reporter.js
+++ b/src/test/integration/ddt_reporter.js
@@ -23,7 +23,14 @@ module.exports = {
     },
 
     reportSpecStarting: function (info) {
-        console.log('\n' + ANSI.BOLD + '> ' + ANSI.BLUE + info.description + ANSI.OFF);
+        if (info.suite.description && info.suite.description.indexOf('Frisby') != -1) {
+            console.log('\n' + ANSI.BOLD + '> ' + ANSI.BLUE + info.suite.description + ANSI.OFF);
+            console.log(info.description
+                .replace('\t', '')
+                .replace('\n', ''));
+        } else {
+            console.log(ANSI.BOLD + '> ' + ANSI.BLUE + info.description + ANSI.OFF);
+        }
     },
 
     reportSpecResults: function (info) {

--- a/src/test/integration/ddt_reporter.js
+++ b/src/test/integration/ddt_reporter.js
@@ -1,0 +1,80 @@
+const ANSI = {
+    OFF: '\u001b[0m',
+    BOLD: '\u001b[1m',
+    BLINK: '\u001b[5m',
+    BLACK: '\u001b[30m',
+    RED: '\u001b[31m',
+    GREEN: '\u001b[32m',
+    YELLOW: '\u001b[33m',
+    BLUE: '\u001b[34m',
+    MAGENTA: '\u001b[35m',
+    CYAN: '\u001b[36m',
+    WHITE: '\u001b[37m'
+};
+
+const reporter = {
+
+    passed: 0,
+    failed: 0,
+    disabled: 0,
+
+    reportRunnerStarting: function (info) {
+        console.log('\n' + ANSI.BOLD + ANSI.MAGENTA + 'Executing tests...' + ANSI.OFF);
+    },
+
+    reportSpecStarting: function (info) {
+        console.log('\n' + ANSI.BOLD + '> ' + ANSI.BLUE + info.description + ANSI.OFF);
+    },
+
+    reportSpecResults: function (info) {
+        var results = info.results();
+        var status;
+        if (results.skipped) {
+            status = 'DISABLED';
+        } else if (results.passed()) {
+            status = 'PASSED';
+        } else {
+            status = 'FAILED';
+        }
+
+        switch (status) {
+
+            case 'PASSED':
+                console.log(ANSI.BOLD + '< ' + ANSI.GREEN + status + ANSI.OFF);
+                reporter.passed++;
+                break;
+
+            case 'FAILED':
+                console.log(ANSI.BOLD + '< ' + ANSI.RED + status + ANSI.OFF);
+                reporter.failed++;
+                results.items_.forEach(function (item) {
+                    if (!item.passed_) {
+                        console.log(ANSI.RED + item.trace.stack + ANSI.OFF);
+                    }
+                });
+                break;
+
+            case 'DISABLED':
+                reporter.disabled++;
+                console.log(ANSI.BOLD + '< ' + ANSI.YELLOW + status + ANSI.OFF);
+                break;
+
+            default:
+                console.log(ANSI.BOLD + '< ' + ANSI.CYAN + status + ANSI.OFF);
+        }
+    },
+
+    reportSuiteResults: function (info) {
+        // don't output anything
+    },
+
+    reportRunnerResults: function (info) {
+        console.log('\n' + new Array(50).join('-') + '\n');
+        console.log(ANSI.GREEN + 'PASSED: ' + ANSI.BOLD + reporter.passed + ANSI.OFF);
+        console.log(ANSI.RED + 'FAILED: ' + ANSI.BOLD + reporter.failed + ANSI.OFF);
+        console.log(ANSI.YELLOW + 'DISABLED: ' + ANSI.BOLD + reporter.disabled + ANSI.OFF);
+    }
+
+};
+
+module.exports = reporter;

--- a/src/test/integration/integration_config.js
+++ b/src/test/integration/integration_config.js
@@ -37,7 +37,7 @@ callbackDomain = 'http://' + ipAddress;
 stableOffset = 5;
 
 jasmine.getEnv().defaultTimeoutInterval = 60 * 1000;
-jasmine.getEnv().reporter = new jasmine.MultiReporter();
+jasmine.getEnv().reporter.subReporters_.length = 0;
 jasmine.getEnv().addReporter(reporter);
 
 console.log("hubDomain " + hubDomain);

--- a/src/test/integration/integration_config.js
+++ b/src/test/integration/integration_config.js
@@ -37,8 +37,8 @@ callbackDomain = 'http://' + ipAddress;
 stableOffset = 5;
 
 jasmine.getEnv().defaultTimeoutInterval = 60 * 1000;
-jasmine.getEnv().reporter = new jasmine.MultiReporter();
-jasmine.getEnv().addReporter(reporter);
+// jasmine.getEnv().reporter = new jasmine.MultiReporter();
+// jasmine.getEnv().addReporter(reporter);
 
 console.log("hubDomain " + hubDomain);
 console.log("satelliteDomain " + satelliteDomain);

--- a/src/test/integration/integration_config.js
+++ b/src/test/integration/integration_config.js
@@ -40,6 +40,29 @@ jasmine.getEnv().defaultTimeoutInterval = 60 * 1000;
 jasmine.getEnv().reporter.subReporters_.length = 0;
 jasmine.getEnv().addReporter(reporter);
 
+// TODO: remove this hacky workaround
+// jasmine-node doesn't provide a way to add reporters so I had to hard code it.
+// in order for the JUnitReporter to still work I needed to hardcode it also, but only
+// when running in Jenkins. This is a short-term solution until I get everything
+// migrated to Jasmine 2.0 (which removes the need for jasmine-node).
+var useJUnitReporter = process.env.JENKINS_URL !== undefined;
+if (useJUnitReporter) {
+
+    // hardcoded values typically provided by the CLI
+    var savePath = 'build/reports/integration/';
+    var consolidate = true;
+    var useDotNotation = true;
+
+    // stolen from jasmine-node's index.js:116-120
+    var existsSync = require('fs').existsSync;
+    if(!existsSync(savePath)) {
+        util.puts('creating junit xml report save path: ' + savePath);
+        mkdirp.sync(savePath, "0755");
+    }
+
+    jasmine.getEnv().addReporter(new jasmine.JUnitXmlReporter(savePath, consolidate, useDotNotation));
+}
+
 console.log("hubDomain " + hubDomain);
 console.log("satelliteDomain " + satelliteDomain);
 console.log("runEncrypted " + runEncrypted);

--- a/src/test/integration/integration_config.js
+++ b/src/test/integration/integration_config.js
@@ -2,6 +2,7 @@ frisby = require('frisby');
 utils = require('./utils.js');
 ip = require('ip');
 var _ = require('lodash');
+var reporter = require('./ddt_reporter');
 
 hubDomain = process.env.hubDomain;
 satelliteDomain = process.env.satelliteDomain;
@@ -35,9 +36,12 @@ channelUrl = hubUrlBase + '/channel';
 callbackDomain = 'http://' + ipAddress;
 stableOffset = 5;
 
+jasmine.getEnv().defaultTimeoutInterval = 60 * 1000;
+jasmine.getEnv().reporter = new jasmine.MultiReporter();
+jasmine.getEnv().addReporter(reporter);
+
 console.log("hubDomain " + hubDomain);
 console.log("satelliteDomain " + satelliteDomain);
 console.log("runEncrypted " + runEncrypted);
 console.log("callbackDomain " + callbackDomain);
-
-jasmine.getEnv().defaultTimeoutInterval = 60 * 1000;
+console.log("default timeout " + jasmine.getEnv().defaultTimeoutInterval + "ms");

--- a/src/test/integration/integration_config.js
+++ b/src/test/integration/integration_config.js
@@ -38,7 +38,7 @@ stableOffset = 5;
 
 jasmine.getEnv().defaultTimeoutInterval = 60 * 1000;
 // jasmine.getEnv().reporter = new jasmine.MultiReporter();
-// jasmine.getEnv().addReporter(reporter);
+jasmine.getEnv().addReporter(reporter);
 
 console.log("hubDomain " + hubDomain);
 console.log("satelliteDomain " + satelliteDomain);

--- a/src/test/integration/integration_config.js
+++ b/src/test/integration/integration_config.js
@@ -37,7 +37,7 @@ callbackDomain = 'http://' + ipAddress;
 stableOffset = 5;
 
 jasmine.getEnv().defaultTimeoutInterval = 60 * 1000;
-// jasmine.getEnv().reporter = new jasmine.MultiReporter();
+jasmine.getEnv().reporter = new jasmine.MultiReporter();
 jasmine.getEnv().addReporter(reporter);
 
 console.log("hubDomain " + hubDomain);

--- a/src/test/integration/websocket_spec.js
+++ b/src/test/integration/websocket_spec.js
@@ -28,10 +28,6 @@ describe(__filename, function () {
                 receivedMessages.push(message.data);
             };
 
-            webSocket.onclose = function () {
-                console.log('closed:', wsURL);
-            };
-
             webSocket.on('open', function () {
                 console.log('opened:', wsURL);
                 setTimeout(done, 5000);
@@ -58,7 +54,12 @@ describe(__filename, function () {
             }
         });
 
-        it('closes websocket', function () {
+        it('closes websocket', function (done) {
+            webSocket.onclose = function () {
+                console.log('closed:', wsURL);
+                done();
+            };
+
             webSocket.close();
         });
 
@@ -90,10 +91,6 @@ describe(__filename, function () {
                 receivedMessages.push(message.data);
             };
 
-            webSocket.onclose = function () {
-                console.log('closed:', wsURL);
-            };
-
             webSocket.on('open', function () {
                 console.log('opened:', wsURL);
                 setTimeout(done, 5000);
@@ -120,7 +117,12 @@ describe(__filename, function () {
             }
         });
 
-        it('closes websocket', function () {
+        it('closes websocket', function (done) {
+            webSocket.onclose = function () {
+                console.log('closed:', wsURL);
+                done();
+            };
+
             webSocket.close();
         });
 
@@ -153,10 +155,6 @@ describe(__filename, function () {
                 receivedMessages.push(message.data);
             };
 
-            webSocket.onclose = function () {
-                console.log('closed:', wsURL);
-            };
-
             webSocket.on('open', function () {
                 console.log('opened:', wsURL);
                 setTimeout(done, 5000);
@@ -183,7 +181,12 @@ describe(__filename, function () {
             }
         });
 
-        it('closes websocket', function () {
+        it('closes websocket', function (done) {
+            webSocket.onclose = function () {
+                console.log('closed:', wsURL);
+                done();
+            };
+
             webSocket.close();
         });
 
@@ -217,10 +220,6 @@ describe(__filename, function () {
                 receivedMessages.push(message.data);
             };
 
-            webSocket.onclose = function () {
-                console.log('closed:', wsURL);
-            };
-
             webSocket.on('open', function () {
                 console.log('opened:', wsURL);
                 setTimeout(done, 5000);
@@ -247,7 +246,12 @@ describe(__filename, function () {
             }
         });
 
-        it('closes websocket', function () {
+        it('closes websocket', function (done) {
+            webSocket.onclose = function () {
+                console.log('closed:', wsURL);
+                done();
+            };
+
             webSocket.close();
         });
 
@@ -282,10 +286,6 @@ describe(__filename, function () {
                 receivedMessages.push(message.data);
             };
 
-            webSocket.onclose = function () {
-                console.log('closed:', wsURL);
-            };
-
             webSocket.on('open', function () {
                 console.log('opened:', wsURL);
                 setTimeout(done, 5000);
@@ -312,7 +312,12 @@ describe(__filename, function () {
             }
         });
 
-        it('closes websocket', function () {
+        it('closes websocket', function (done) {
+            webSocket.onclose = function () {
+                console.log('closed:', wsURL);
+                done();
+            };
+
             webSocket.close();
         });
 
@@ -336,10 +341,6 @@ describe(__filename, function () {
             webSocket.onmessage = function (message) {
                 console.log('received:', message.data);
                 receivedMessages.push(message.data);
-            };
-
-            webSocket.onclose = function () {
-                console.log('closed:', wsURL);
             };
 
             webSocket.on('open', function () {
@@ -369,7 +370,12 @@ describe(__filename, function () {
             }
         });
 
-        it('closes websocket', function () {
+        it('closes websocket', function (done) {
+            webSocket.onclose = function () {
+                console.log('closed:', wsURL);
+                done();
+            };
+
             webSocket.close();
         });
 


### PR DESCRIPTION
resolves #831 

This is the first part of multiple changes to the integration tests. This change causes the integration tests to ignore the jasmine-node parameters ```--forceexit```, ```--junitreport```, and ```--output <directory>```. Instead those values are hardcoded. Once we move to Jasmine 2.0 we'll have control over those values once again.