### PR TITLE
Updated to Jasmine 2.6

### DIFF
--- a/src/test/integration/channel_case_sensitive_spec.js
+++ b/src/test/integration/channel_case_sensitive_spec.js
@@ -117,9 +117,10 @@ describe(testName, function () {
         getTwo(upperCase, '/time/hour?stable=false', done);
      });*/
 
+    // this delay is to allow the item time for the S3 write.
+    utils.itSleeps(5000);
+
     it("gets latest 2 " + upperCase, function (done) {
-        // this delay is to allow the item time for the S3 write.
-        utils.sleep(5000);
         getTwo(upperCase, '/latest/2?stable=false', done);
     });
 

--- a/src/test/integration/ddt_reporter.js
+++ b/src/test/integration/ddt_reporter.js
@@ -20,25 +20,20 @@ module.exports = {
 
     failures: [],
 
-    reportRunnerStarting: function (info) {
+    jasmineStarted: function (info) {
         console.log('\n' + ANSI.BOLD + ANSI.MAGENTA + 'Executing tests...' + ANSI.OFF);
     },
 
-    reportSpecStarting: function (info) {
+    suiteStarted: function (info) {
+        // don't output anything
+    },
+
+    specStarted: function (info) {
         console.log('\n' + ANSI.BOLD + '> ' + ANSI.BLUE + info.description + ANSI.OFF);
     },
 
-    reportSpecResults: function (info) {
-        var results = info.results();
-        var status;
-        if (results.skipped) {
-            status = 'DISABLED';
-        } else if (results.passed()) {
-            status = 'PASSED';
-        } else {
-            status = 'FAILED';
-        }
-
+    specDone: function (info) {
+        var status = info.status.toUpperCase();
         switch (status) {
 
             case 'PASSED':
@@ -49,19 +44,18 @@ module.exports = {
             case 'FAILED':
                 console.log(ANSI.BOLD + '< ' + ANSI.RED + status + ANSI.OFF);
                 this.failed++;
-                var self = this;
-                results.items_.forEach(function (item) {
-                    if (!item.passed_) {
-                        var failure = item.trace.stack;
-                        if (failure === undefined) {
-                            console.log('An error occured but a stack trace couldn\'t be found');
-                            console.log('DEBUG INFO:', item);
-                            exit(1);
-                        }
-                        console.log(ANSI.RED + failure + ANSI.OFF);
-                        self.failures.push(failure);
+                for (var i = 0; i < info.failedExpectations.length; ++i) {
+                    var failure = info.failedExpectations[i].stack;
+
+                    if (failure === undefined) {
+                        console.log('An error occured but a stack trace couldn\'t be found');
+                        console.log('DEBUG INFO:', item);
+                        exit(1);
                     }
-                });
+
+                    console.log(ANSI.RED + failure + ANSI.OFF);
+                    this.failures.push(failure);
+                }
                 break;
 
             case 'DISABLED':
@@ -74,11 +68,11 @@ module.exports = {
         }
     },
 
-    reportSuiteResults: function (info) {
+    suiteDone: function (info) {
         // don't output anything
     },
 
-    reportRunnerResults: function (info) {
+    jasmineDone: function (info) {
         if (this.failed) {
             var twentyDashes = new Array(20).join('-');
             console.log('\n' + twentyDashes + ' FAILURE SUMMARY ' + twentyDashes);

--- a/src/test/integration/ddt_reporter.js
+++ b/src/test/integration/ddt_reporter.js
@@ -92,8 +92,6 @@ module.exports = {
         console.log(ANSI.GREEN + 'PASSED: ' + ANSI.BOLD + this.passed + ANSI.OFF);
         console.log(ANSI.RED + 'FAILED: ' + ANSI.BOLD + this.failed + ANSI.OFF);
         console.log(ANSI.YELLOW + 'DISABLED: ' + ANSI.BOLD + this.disabled + ANSI.OFF + '\n');
-
-        process.exit(this.failed ? 1 : 0);
     }
 
 };

--- a/src/test/integration/ddt_reporter.js
+++ b/src/test/integration/ddt_reporter.js
@@ -21,11 +21,18 @@ module.exports = {
     failures: [],
 
     jasmineStarted: function (info) {
-        console.log('\n' + ANSI.BOLD + ANSI.MAGENTA + 'Executing tests...' + ANSI.OFF);
+        var message = 'Executing ' + info.totalSpecsDefined + ' specs at ' + __dirname;
+        console.log('\n' + ANSI.BOLD + ANSI.MAGENTA + message + ANSI.OFF);
     },
 
     suiteStarted: function (info) {
-        // don't output anything
+        var indexOfFilename = info.description.lastIndexOf('/') + 1;
+        var filename = info.description.slice(indexOfFilename);
+        var line = new Array(50).join('-');
+        console.log('\n');
+        console.log(line);
+        console.log(ANSI.BOLD + '  ' + filename + ANSI.OFF);
+        console.log(line);
     },
 
     specStarted: function (info) {

--- a/src/test/integration/events_lifecycle_spec.js
+++ b/src/test/integration/events_lifecycle_spec.js
@@ -35,31 +35,32 @@ describe(testName, function () {
         source.addEventListener('open', function (e) {
             console.log('opened');
         }, false);
-
-
-        utils.sleepQ(1000)
+    });
+    
+    utils.itSleeps(1000);
+    
+    it('posts items', function (done) {
+        utils.postItemQ(channelResource)
             .then(function (value) {
+                addPostedItem(value);
                 return utils.postItemQ(channelResource);
-            }).then(function (value) {
-                return postedItem(value, true);
-            }).then(function (value) {
-                return postedItem(value, true);
-            }).then(function (value) {
-                return postedItem(value, true);
-            }).then(function (value) {
-                postedItem(value, false);
+            })
+            .then(function (value) {
+                addPostedItem(value);
+                return utils.postItemQ(channelResource);
+            })
+            .then(function (value) {
+                addPostedItem(value);
+                return utils.postItemQ(channelResource);
+            })
+            .then(function (value) {
+                addPostedItem(value);
+                done();
             });
-
-        waitsFor(function () {
-            return events.length == 4;
-        }, 9999);
-
-        function postedItem(value, post) {
+        
+        function addPostedItem(value) {
             console.log('posted ', value.body._links.self.href);
             postedItems.push(value.body._links.self.href);
-            if (post) {
-                return utils.postItemQ(channelResource);
-            }
         }
 
     }, 10 * 1000);

--- a/src/test/integration/events_lifecycle_spec.js
+++ b/src/test/integration/events_lifecycle_spec.js
@@ -65,8 +65,13 @@ describe(testName, function () {
 
     }, 10 * 1000);
 
+    it('waits for data', function (done) {
+        utils.waitForData(postedItems, events, done);
+    });
+
     it('verifies events', function () {
-        for (i = 0; i < postedItems.length; i++) {
+        console.log('events:', events);
+        for (var i = 0; i < postedItems.length; i++) {
             expect(postedItems[i]).toBe(events[i]);
         }
 

--- a/src/test/integration/install.sh
+++ b/src/test/integration/install.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-sudo npm install -g async@~1.3.0 chai@~1.9.0 feed-read@~0.0.1 jasmine@~2.6.0 lodash@3.7.0 moment@~2.5.0 request@~2.33.0 superagent@~0.16.0 ws@~0.4.0 q@1.0.1 ip@0.3.0 parse-link-header eventsource@0.1.6

--- a/src/test/integration/install.sh
+++ b/src/test/integration/install.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-sudo npm install -g async@~1.3.0 chai@~1.9.0 feed-read@~0.0.1 jasmine-node@~1.14.5 lodash@3.7.0 moment@~2.5.0 request@~2.33.0 superagent@~0.16.0 ws@~0.4.0 q@1.0.1 ip@0.3.0 parse-link-header eventsource@0.1.6
+sudo npm install -g async@~1.3.0 chai@~1.9.0 feed-read@~0.0.1 jasmine@~2.6.0 lodash@3.7.0 moment@~2.5.0 request@~2.33.0 superagent@~0.16.0 ws@~0.4.0 q@1.0.1 ip@0.3.0 parse-link-header eventsource@0.1.6

--- a/src/test/integration/integration_config.js
+++ b/src/test/integration/integration_config.js
@@ -1,7 +1,6 @@
 utils = require('./utils.js');
 ip = require('ip');
 var _ = require('lodash');
-var reporter = require('./ddt_reporter');
 
 hubDomain = process.env.hubDomain;
 satelliteDomain = process.env.satelliteDomain;

--- a/src/test/integration/integration_config.js
+++ b/src/test/integration/integration_config.js
@@ -35,13 +35,10 @@ channelUrl = hubUrlBase + '/channel';
 callbackDomain = 'http://' + ipAddress;
 stableOffset = 5;
 
-jasmine.getEnv().defaultTimeoutInterval = 60 * 1000;
-jasmine.getEnv().reporter.subReporters_.length = 0;
-jasmine.getEnv().addReporter(reporter);
-process.removeAllListeners('exit');
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 60 * 1000;
 
 console.log("hubDomain " + hubDomain);
 console.log("satelliteDomain " + satelliteDomain);
 console.log("runEncrypted " + runEncrypted);
 console.log("callbackDomain " + callbackDomain);
-console.log("default timeout " + jasmine.getEnv().defaultTimeoutInterval + "ms");
+console.log("default timeout " + jasmine.DEFAULT_TIMEOUT_INTERVAL + "ms");

--- a/src/test/integration/integration_config.js
+++ b/src/test/integration/integration_config.js
@@ -5,7 +5,6 @@ var _ = require('lodash');
 hubDomain = process.env.hubDomain;
 satelliteDomain = process.env.satelliteDomain;
 runEncrypted = process.env.runEncrypted || false;
-integrationTestPath = process.env.integrationTestPath || 'src/test/integration/';
 callbackPort = runEncrypted = process.env.callbackPort || 8888;
 
 //this does not report the correct ip address when connected via the vpn

--- a/src/test/integration/jasmine.js
+++ b/src/test/integration/jasmine.js
@@ -1,0 +1,22 @@
+const Jasmine = require('jasmine');
+const reporter = require('./ddt_reporter');
+
+var specs = process.argv.slice(2);
+var jasmine = new Jasmine();
+
+global.hubDomain = process.env.hubDomain;
+
+jasmine.loadConfig({
+    spec_dir: '.',
+    spec_files: ['**/*_spec.js'],
+    stopSpecOnExpectationFailure: true
+});
+
+jasmine.clearReporters();
+jasmine.addReporter(reporter);
+
+if (specs.length > 0) {
+    jasmine.execute(specs);
+} else {
+    jasmine.execute();
+}

--- a/src/test/integration/latest_item_in_channel_spec.js
+++ b/src/test/integration/latest_item_in_channel_spec.js
@@ -62,7 +62,7 @@ describe(testName, function () {
             });
     });
 
-    utils.sleep(6000);
+    utils.itSleeps(6000);
     utils.addItem(channelResource, 201);
 
     it("gets latest stable in channel ", function (done) {

--- a/src/test/integration/package-lock.json
+++ b/src/test/integration/package-lock.json
@@ -29,20 +29,25 @@
       "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
       "optional": true
     },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
     "boom": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
       "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs="
     },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI="
+    },
     "chai": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
       "integrity": "sha1-5AMcyHZURhp1lD5aNatG6vOcHrk="
-    },
-    "coffee-script": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
-      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
     },
     "combined-stream": {
       "version": "0.0.7",
@@ -54,6 +59,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
       "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "cookiejar": {
       "version": "1.3.0",
@@ -98,15 +108,15 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
       "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI="
     },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
+    },
     "feed-read": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/feed-read/-/feed-read-0.0.1.tgz",
       "integrity": "sha1-LaOTTX8Vu9vldNysVAOCHkFhY4s="
-    },
-    "fileset": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.8.tgz",
-      "integrity": "sha1-UGuRqTluqn4y+0KoQHfHoMc2t0E="
     },
     "forever-agent": {
       "version": "0.5.2",
@@ -132,27 +142,15 @@
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz",
       "integrity": "sha1-Kz9MQRy7X91pXESEPiojUUpDIxo="
     },
-    "gaze": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.3.4.tgz",
-      "integrity": "sha1-X5S92gr+U7xxCWm81vKCVI1gwnk="
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-      "dependencies": {
-        "minimatch": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0="
-        }
-      }
-    },
-    "growl": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz",
-      "integrity": "sha1-3i1mE20ALhErpw8/EMMc98NQsto="
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
     },
     "hawk": {
       "version": "1.0.0",
@@ -171,6 +169,11 @@
       "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
       "optional": true
     },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+    },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -181,20 +184,15 @@
       "resolved": "https://registry.npmjs.org/ip/-/ip-0.3.3.tgz",
       "integrity": "sha1-jugwnpLwsEDSh/cu+soaIXAtP7Q="
     },
-    "jasmine-growl-reporter": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/jasmine-growl-reporter/-/jasmine-growl-reporter-0.0.3.tgz",
-      "integrity": "sha1-uHrlUeNZ0orVIXdl6u9sB7dj9sg="
+    "jasmine": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.6.0.tgz",
+      "integrity": "sha1-ayLnCIPo5YnUVjRhU7TSBt2+IX8="
     },
-    "jasmine-node": {
-      "version": "1.14.5",
-      "resolved": "https://registry.npmjs.org/jasmine-node/-/jasmine-node-1.14.5.tgz",
-      "integrity": "sha1-GOg5e4VpJO53ADZmw3MbWupQw50="
-    },
-    "jasmine-reporters": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/jasmine-reporters/-/jasmine-reporters-1.0.2.tgz",
-      "integrity": "sha1-q2E+1Zd9x0h+hbPBL2qOqNsq3jE="
+    "jasmine-core": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.6.4.tgz",
+      "integrity": "sha1-3skmzQqfoof7bbXHVfpIfnTOysU="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -205,11 +203,6 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
       "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-    },
-    "lru-cache": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
     },
     "methods": {
       "version": "0.0.1",
@@ -222,14 +215,9 @@
       "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
     },
     "minimatch": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-      "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo="
-    },
-    "mkdirp": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-      "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
     },
     "moment": {
       "version": "2.18.1",
@@ -252,6 +240,11 @@
       "integrity": "sha1-y1QPk7srIqfVlBaRoojWDo6pOG4=",
       "optional": true
     },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+    },
     "options": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
@@ -266,6 +259,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-1.0.1.tgz",
       "integrity": "sha1-vt/g0hGK64S+deewJUGeyKYRQKc="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "punycode": {
       "version": "1.4.1",
@@ -298,11 +296,6 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.33.0.tgz",
       "integrity": "sha1-UWeHgTFyYHDsYzdS6iMKI3ncZf8="
     },
-    "requirejs": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.4.tgz",
-      "integrity": "sha512-qPD5gRrj6kGQ0ZySAJgqbArkaDqPMbQIT0zSZDkIv1mfA17w/tR2Faq5l2qqRf2CdQx6FWln9nUrgd2UDzb19A=="
-    },
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -312,11 +305,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/sax/-/sax-0.3.5.tgz",
       "integrity": "sha1-iPz8H3PAyLvVt8d2ttPzUB7tBz0="
-    },
-    "sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
     },
     "sntp": {
       "version": "0.2.4",
@@ -373,10 +361,10 @@
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
       "integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns="
     },
-    "walkdir": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
-      "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI="
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
       "version": "0.4.32",

--- a/src/test/integration/package-lock.json
+++ b/src/test/integration/package-lock.json
@@ -1,0 +1,392 @@
+{
+  "lockfileVersion": 1,
+  "dependencies": {
+    "asn1": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+      "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
+      "optional": true
+    },
+    "assert-plus": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+      "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
+      "optional": true
+    },
+    "assertion-error": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
+      "integrity": "sha1-x/hUOP3UZrx8oWq5DIFRN5el0js="
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+    },
+    "aws-sign2": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+      "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
+      "optional": true
+    },
+    "boom": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+      "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs="
+    },
+    "chai": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
+      "integrity": "sha1-5AMcyHZURhp1lD5aNatG6vOcHrk="
+    },
+    "coffee-script": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
+    },
+    "combined-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+      "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
+      "optional": true
+    },
+    "commander": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+      "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E="
+    },
+    "cookiejar": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-1.3.0.tgz",
+      "integrity": "sha1-3QCzVnkCHpnL1OhVua0EGRNHR2U="
+    },
+    "cryptiles": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+      "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
+      "optional": true
+    },
+    "ctype": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+      "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
+      "optional": true
+    },
+    "debug": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+      "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI="
+    },
+    "delayed-stream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+      "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
+      "optional": true
+    },
+    "emitter-component": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.0.0.tgz",
+      "integrity": "sha1-8E3Rj8PcPpp0y8DzELCIZm5MAW8="
+    },
+    "eventsource": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
+      "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI="
+    },
+    "feed-read": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/feed-read/-/feed-read-0.0.1.tgz",
+      "integrity": "sha1-LaOTTX8Vu9vldNysVAOCHkFhY4s="
+    },
+    "fileset": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.8.tgz",
+      "integrity": "sha1-UGuRqTluqn4y+0KoQHfHoMc2t0E="
+    },
+    "forever-agent": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+      "integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA="
+    },
+    "form-data": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+      "integrity": "sha1-kavXiKupcCsaq/qLwBAxoqyeOxI=",
+      "optional": true,
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "optional": true
+        }
+      }
+    },
+    "formidable": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz",
+      "integrity": "sha1-Kz9MQRy7X91pXESEPiojUUpDIxo="
+    },
+    "gaze": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.3.4.tgz",
+      "integrity": "sha1-X5S92gr+U7xxCWm81vKCVI1gwnk="
+    },
+    "glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+      "dependencies": {
+        "minimatch": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0="
+        }
+      }
+    },
+    "growl": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz",
+      "integrity": "sha1-3i1mE20ALhErpw8/EMMc98NQsto="
+    },
+    "hawk": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
+      "integrity": "sha1-uQuxaYByhUEdp//LjdJZhQLTtS0=",
+      "optional": true
+    },
+    "hoek": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+      "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU="
+    },
+    "http-signature": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+      "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
+      "optional": true
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ip": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-0.3.3.tgz",
+      "integrity": "sha1-jugwnpLwsEDSh/cu+soaIXAtP7Q="
+    },
+    "jasmine-growl-reporter": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/jasmine-growl-reporter/-/jasmine-growl-reporter-0.0.3.tgz",
+      "integrity": "sha1-uHrlUeNZ0orVIXdl6u9sB7dj9sg="
+    },
+    "jasmine-node": {
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/jasmine-node/-/jasmine-node-1.14.5.tgz",
+      "integrity": "sha1-GOg5e4VpJO53ADZmw3MbWupQw50="
+    },
+    "jasmine-reporters": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/jasmine-reporters/-/jasmine-reporters-1.0.2.tgz",
+      "integrity": "sha1-q2E+1Zd9x0h+hbPBL2qOqNsq3jE="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "lodash": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+    },
+    "methods": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-0.0.1.tgz",
+      "integrity": "sha1-J3yQ+L7zlwlkWoNxxRw7bGSOBow="
+    },
+    "mime": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+      "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
+    },
+    "minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo="
+    },
+    "mkdirp": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+      "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
+    },
+    "moment": {
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
+      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
+    },
+    "nan": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz",
+      "integrity": "sha1-riT4hQgY1mL8q1rPfzuVv6oszzg="
+    },
+    "node-uuid": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+    },
+    "oauth-sign": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz",
+      "integrity": "sha1-y1QPk7srIqfVlBaRoojWDo6pOG4=",
+      "optional": true
+    },
+    "options": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
+    },
+    "original": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
+      "integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs="
+    },
+    "parse-link-header": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-1.0.1.tgz",
+      "integrity": "sha1-vt/g0hGK64S+deewJUGeyKYRQKc="
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "optional": true
+    },
+    "q": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
+      "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE="
+    },
+    "qs": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
+      "integrity": "sha1-bgFQmP9RlouKPIGQAdXyyJvEsQc="
+    },
+    "querystringify": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
+      "integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw="
+    },
+    "reduce-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz",
+      "integrity": "sha1-4Mk1QsV0UhvqE98PlIjtgqt3xdo="
+    },
+    "request": {
+      "version": "2.33.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.33.0.tgz",
+      "integrity": "sha1-UWeHgTFyYHDsYzdS6iMKI3ncZf8="
+    },
+    "requirejs": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.4.tgz",
+      "integrity": "sha512-qPD5gRrj6kGQ0ZySAJgqbArkaDqPMbQIT0zSZDkIv1mfA17w/tR2Faq5l2qqRf2CdQx6FWln9nUrgd2UDzb19A=="
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "sax": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-0.3.5.tgz",
+      "integrity": "sha1-iPz8H3PAyLvVt8d2ttPzUB7tBz0="
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
+    },
+    "sntp": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+      "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
+      "optional": true
+    },
+    "superagent": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-0.16.0.tgz",
+      "integrity": "sha1-8430pHZWXf/bqgd2S4Ghnwqzik4=",
+      "dependencies": {
+        "mime": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.5.tgz",
+          "integrity": "sha1-nu0HMCKov14WyFZsaGe4gyv7+hM="
+        },
+        "qs": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.5.tgz",
+          "integrity": "sha1-KUsmjksNQlD23eGbO4s0k13/FO8="
+        }
+      }
+    },
+    "tinycolor": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz",
+      "integrity": "sha1-MgtaUtg6u1l42Bo+iH1K77FaYWQ="
+    },
+    "tough-cookie": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+      "optional": true
+    },
+    "tunnel-agent": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz",
+      "integrity": "sha1-rWgbaPUyGtKCfEz7G31d8s/pQu4=",
+      "optional": true
+    },
+    "type-detect": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+      "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
+    },
+    "underscore": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+    },
+    "url-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
+      "integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns="
+    },
+    "walkdir": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
+      "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI="
+    },
+    "ws": {
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
+      "integrity": "sha1-eHphVEFPPJntg8V3IVOyD+sM7DI="
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    }
+  }
+}

--- a/src/test/integration/package.json
+++ b/src/test/integration/package.json
@@ -1,0 +1,17 @@
+{
+  "dependencies": {
+    "async": "^1.3.0",
+    "chai": "^1.9.0",
+    "eventsource": "^0.1.6",
+    "feed-read": "0.0.1",
+    "ip": "^0.3.0",
+    "jasmine-node": "^1.14.5",
+    "lodash": "^3.7.0",
+    "moment": "^2.5.0",
+    "parse-link-header": "^1.0.1",
+    "q": "^1.0.1",
+    "request": "~2.33.0",
+    "superagent": "^0.16.0",
+    "ws": "^0.4.0"
+  }
+}

--- a/src/test/integration/package.json
+++ b/src/test/integration/package.json
@@ -5,7 +5,7 @@
     "eventsource": "^0.1.6",
     "feed-read": "0.0.1",
     "ip": "^0.3.0",
-    "jasmine-node": "^1.14.5",
+    "jasmine": "^2.6.0",
     "lodash": "^3.7.0",
     "moment": "^2.5.0",
     "parse-link-header": "^1.0.1",

--- a/src/test/integration/replication_deletion_spec.js
+++ b/src/test/integration/replication_deletion_spec.js
@@ -14,8 +14,9 @@ describe(testName, function () {
 
     var localChannelUrl = hubUrlBase + '/channel/' + channelName;
 
+    utils.itSleeps(1000);
+
     it('tries to add item to channel ' + channelName, function (done) {
-        utils.sleep(1000);
         request.post({
                 url: localChannelUrl,
                 headers: {"Content-Type": "application/json", user: 'somebody'},

--- a/src/test/integration/stream_lifecycle_spec.js
+++ b/src/test/integration/stream_lifecycle_spec.js
@@ -14,43 +14,57 @@ var testName = __filename;
  * 3 - post items into the channel
  * 4 - verify that the item payloads are returned within delta time
  */
-describe(testName, function () {
+
+xdescribe(testName, function () {
+
     var callbackItems = [];
     var postedItems = [];
 
     utils.createChannel(channelName, false, testName);
 
-    /*it('calls stream and waits for items', function (done) {
+    it('opens a stream', function (done) {
+        var url = channelResource + '/stream';
+        var headers = {"Content-Type": "application/json"};
 
-        request.get({
-                url: channelResource + '/stream',
-                headers: {"Content-Type": "application/json"}
-            },
-            function (err, response, body) {
-                expect(err).toBeNull();
+        utils.httpGet(url, headers)
+            .then(function (response) {
                 expect(response.statusCode).toBe(200);
                 console.log('body', body);
+            })
+            .catch(function (error) {
+                expect(error).toBeNull();
+            })
+            .fin(function () {
                 done();
             });
+    });
 
+    it('inserts multiple items', function (done) {
         utils.postItemQ(channelResource)
             .then(function (value) {
-                return postedItem(value, true);
-            }).then(function (value) {
-                return postedItem(value, true);
-            }).then(function (value) {
-                return postedItem(value, true);
-            }).then(function (value) {
-                postedItem(value, false);
+                postedItems.push(value);
+                return utils.postItemQ(channelResource);
+            })
+            .then(function (value) {
+                postedItems.push(value);
+                return utils.postItemQ(channelResource);
+            })
+            .then(function (value) {
+                postedItems.push(value);
+                return utils.postItemQ(channelResource);
+            })
+            .then(function (value) {
+                postedItems.push(value);
+                done();
             });
+    });
 
-        waitsFor(function () {
-            return callbackItems.length == 4;
-        }, 20 * 1000);
+    it('waits for the data', function (done) {
+        utils.waitForData(callbackItems, postedItems, done);
+    });
 
-
-     });*/
-
+    it('verifies we got the correct number of items', function (done) {
+        expect(callbackItems.length).toEqual(4);
+    });
 
 });
-

--- a/src/test/integration/utils.js
+++ b/src/test/integration/utils.js
@@ -507,8 +507,8 @@ function serverResponse(request, response, callback) {
 exports.startHttpsServer = function startHttpsServer(port, callback, done) {
 
     var options = {
-        key: fs.readFileSync(integrationTestPath + 'localhost.key'),
-        cert: fs.readFileSync(integrationTestPath + 'localhost.cert')
+        key: fs.readFileSync('localhost.key'),
+        cert: fs.readFileSync('localhost.cert')
     };
 
     var server = https.createServer(options, function (request, response) {

--- a/src/test/integration/utils.js
+++ b/src/test/integration/utils.js
@@ -483,10 +483,9 @@ exports.startServer = function startServer(server, port, callback, done) {
 };
 
 exports.closeServer = function closeServer(server, callback) {
-    server.close(function () {
-        console.log('server closed on port', server.getPort());
-        if (callback) callback();
-    });
+    console.log('closing server on port', server.address().port);
+    callback = callback || function () {};
+    server.close(callback);
 };
 
 exports.parseJson = function parseJson(response, description) {

--- a/src/test/integration/utils.js
+++ b/src/test/integration/utils.js
@@ -427,24 +427,9 @@ exports.getQ = function getQ(url, status, stable) {
 };
 
 exports.itSleeps = function itSleeps(millis) {
-    it('sleeps', function () {
-        utils.sleep(millis);
-    })
-};
-
-exports.sleep = function sleep(millis) {
-    runs(function() {
-        console.log('sleeping for ' + millis);
-        flag = false;
-
-        setTimeout(function() {
-            flag = true;
-        }, millis);
+    it('sleeps for ' + millis + 'ms', function (done) {
+        setTimeout(done, millis);
     });
-
-    waitsFor(function() {
-        return flag;
-    }, millis + 1000);
 };
 
 exports.sleepQ = function sleepQ(millis) {

--- a/src/test/integration/utils.js
+++ b/src/test/integration/utils.js
@@ -438,9 +438,9 @@ exports.getPort = function getPort() {
     return port;
 };
 
-exports.startHttpServer = function startHTTPServer(port, callback, done) {
+exports.startHttpServer = function startHttpServer(port, callback, done) {
     var httpServer = new http.Server();
-    return startServer(httpServer, port, callback, done);
+    return utils.startServer(httpServer, port, callback, done);
 };
 
 exports.startHttpsServer = function startHttpsServer(port, callback, done) {
@@ -449,7 +449,7 @@ exports.startHttpsServer = function startHttpsServer(port, callback, done) {
         cert: fs.readFileSync('localhost.cert')
     };
     var httpsServer = new https.Server(options);
-    return startServer(httpsServer, port, callback, done);
+    return utils.startServer(httpsServer, port, callback, done);
 };
 
 exports.startServer = function startServer(server, port, callback, done) {

--- a/src/test/integration/utils.js
+++ b/src/test/integration/utils.js
@@ -432,14 +432,6 @@ exports.itSleeps = function itSleeps(millis) {
     });
 };
 
-exports.sleepQ = function sleepQ(millis) {
-    var deferred = Q.defer();
-    setTimeout(function () {
-        deferred.resolve('slept');
-    }, millis);
-    return deferred.promise;
-};
-
 exports.timeout = function timeout(millis) {
     it('waits for ' + millis, function (done) {
         setTimeout(function () {

--- a/src/test/integration/utils.js
+++ b/src/test/integration/utils.js
@@ -432,14 +432,6 @@ exports.itSleeps = function itSleeps(millis) {
     });
 };
 
-exports.timeout = function timeout(millis) {
-    it('waits for ' + millis, function (done) {
-        setTimeout(function () {
-            done()
-        }, millis);
-    });
-};
-
 exports.getPort = function getPort() {
     var port = callbackPort++;
     console.log('using port', port);

--- a/src/test/integration/utils.js
+++ b/src/test/integration/utils.js
@@ -549,3 +549,17 @@ exports.getQuery = function getQuery(url, status, expectedUris, done) {
             done();
         });
 };
+
+exports.waitForData = function waitForData(actual, expected, done) {
+    expect(actual).isPrototypeOf(Array);
+    expect(expected).isPrototypeOf(Array);
+    setTimeout(function () {
+        if (actual.length !== expected.length) {
+            waitForMessages(actual, expected, done);
+        } else {
+            console.log('expected:', expected);
+            console.log('actual:', actual);
+            done();
+        }
+    }, 500);
+};

--- a/src/test/integration/webhook_change_bad_url_ignore.js
+++ b/src/test/integration/webhook_change_bad_url_ignore.js
@@ -72,6 +72,7 @@ describe(testName, function () {
     });
     
     it('closes the callback server', function (done) {
+        expect(callbackServer).toBeDefined();
         utils.closeServer(callbackServer, done);
     });
 

--- a/src/test/integration/webhook_change_bad_url_ignore.js
+++ b/src/test/integration/webhook_change_bad_url_ignore.js
@@ -21,16 +21,15 @@ var testName = __filename;
  */
 describe(testName, function () {
 
-    var portB = utils.getPort();
+    var callbackServer;
+    var port = utils.getPort();
 
-    var itemsB = [];
-    var postedItem;
     var badConfig = {
         callbackUrl: 'http://localhost:8080/nothing',
         channelUrl: channelResource
     };
-    var webhookConfigB = {
-        callbackUrl: callbackDomain + ':' + portB + '/',
+    var goodConfig = {
+        callbackUrl: callbackDomain + ':' + port + '/',
         channelUrl: channelResource
     };
 
@@ -40,30 +39,40 @@ describe(testName, function () {
 
     utils.itSleeps(2000);
 
-    utils.putWebhook(webhookName, webhookConfigB, 200, testName);
+    utils.putWebhook(webhookName, goodConfig, 200, testName);
 
     utils.itSleeps(10000);
 
-    it('runs callback server: channel:' + channelName + ' webhook:' + webhookName, function () {
-        utils.startServer(portB, function (string) {
-            console.log('called webhook ' + webhookName + ' ' + string);
-            itemsB.push(string);
-        });
+    var receivedItems = [];
 
+    it('starts a callback server', function (done) {
+        callbackServer = utils.startHttpServer(port, function (string) {
+            console.log('called webhook ' + webhookName + ' ' + string);
+            receivedItems.push(string);
+        }, done);
+    });
+    
+    var itemURL;
+    
+    it('posts and item', function (done) {
         utils.postItemQ(channelResource)
             .then(function (value) {
-                postedItem = value.body._links.self.href;
+                itemURL = value.body._links.self.href;
+                done();
             });
-
-        waitsFor(function () {
-            return itemsB.length == 1;
-        }, 71001);
-
+    });
+    
+    it('waits for data', function (done) {
+       utils.waitForData(receivedItems, [itemURL], done); 
+    });
+    
+    it('verifies we got the item through the callback', function () {
+        expect(receivedItems.length).toBe(1);
+        expect(receivedItems).toContain(itemURL);
+    });
+    
+    it('closes the callback server', function (done) {
+        utils.closeServer(callbackServer, done);
     });
 
-    utils.closeServer(function () {
-        expect(itemsB.length).toBe(1);
-        expect(JSON.parse(itemsB[0]).uris[0]).toBe(postedItem);
-    }, testName);
 });
-

--- a/src/test/integration/webhook_change_url_spec.js
+++ b/src/test/integration/webhook_change_url_spec.js
@@ -84,6 +84,7 @@ describe(testName, function () {
     });
 
     it('closes the callback server', function (done) {
+        expect(callbackServer).toBeDefined();
         utils.closeServer(callbackServer, done);
     });
 

--- a/src/test/integration/webhook_delete_change_spec.js
+++ b/src/test/integration/webhook_delete_change_spec.js
@@ -96,10 +96,12 @@ describe(testName, function () {
     });
 
     it('closes the first callback server', function (done) {
+        expect(callbackServerA).toBeDefined();
         utils.closeServer(callbackServerA, done);
     });
 
     it('closes the second callback server', function (done) {
+        expect(callbackServerB).toBeDefined();
         utils.closeServer(callbackServerB, done);
     });
 

--- a/src/test/integration/webhook_delete_change_spec.js
+++ b/src/test/integration/webhook_delete_change_spec.js
@@ -24,6 +24,8 @@ var testName = __filename;
 
 describe(testName, function () {
 
+    var callbackServerA;
+    var callbackServerB;
     var portA = utils.getPort();
     var portB = utils.getPort();
 
@@ -44,20 +46,22 @@ describe(testName, function () {
 
     utils.putWebhook(webhookName, webhookConfigA, 201, testName);
 
-    it('runs callback server', function () {
-        utils.startServer(portA, function (string) {
+    it('starts the first callback server', function (done) {
+        callbackServerA = utils.startHttpServer(portA, function (string) {
             callbackItemsA.push(string);
-        });
+        }, done);
+    });
 
+    it('posts the first item', function (done) {
         utils.postItemQ(channelResource)
             .then(function (value) {
                 postedItemsA.push(value.body._links.self.href);
+                done();
             });
+    });
 
-        waitsFor(function () {
-            return callbackItemsA.length == 1;
-        }, 11999);
-
+    it('waits for data', function (done) {
+        utils.waitForData(callbackItemsA, postedItemsA, done);
     });
 
     utils.deleteWebhook(webhookName);
@@ -66,27 +70,38 @@ describe(testName, function () {
 
     utils.putWebhook(webhookName, webhookConfigB, 201, testName);
 
-    it('runs callback server', function () {
-        utils.startServer(portB, function (string) {
+    it('starts the second callback server', function (done) {
+        callbackServerB = utils.startHttpServer(portB, function (string) {
             callbackItemsB.push(string);
-        });
+        }, done);
+    });
 
+    it('posts the second item', function (done) {
         utils.postItemQ(channelResource)
             .then(function (value) {
                 postedItemsB.push(value.body._links.self.href);
+                done();
             });
-
-        waitsFor(function () {
-            return callbackItemsB.length == 1;
-        }, 11998);
-
     });
 
-    utils.closeServer(function () {
+    it('waits for data', function (done) {
+        utils.waitForData(callbackItemsB, postedItemsB, done);
+    });
+
+    it('verifies we got what we expected through the callback', function () {
         expect(callbackItemsA.length).toBe(1);
         expect(callbackItemsB.length).toBe(1);
         expect(JSON.parse(callbackItemsA[0]).uris[0]).toBe(postedItemsA[0]);
         expect(JSON.parse(callbackItemsB[0]).uris[0]).toBe(postedItemsB[0]);
-    }, testName);
+    });
+
+    it('closes the first callback server', function (done) {
+        utils.closeServer(callbackServerA, done);
+    });
+
+    it('closes the second callback server', function (done) {
+        utils.closeServer(callbackServerB, done);
+    });
+
 });
 

--- a/src/test/integration/webhook_deletion_spec.js
+++ b/src/test/integration/webhook_deletion_spec.js
@@ -80,6 +80,7 @@ describe(testName, function () {
     });
 
     it('closes the callback server', function (done) {
+        expect(callbackServer).toBeDefined();
         utils.closeServer(callbackServer, done);
     });
 

--- a/src/test/integration/webhook_https_self_signed_spec.js
+++ b/src/test/integration/webhook_https_self_signed_spec.js
@@ -63,6 +63,7 @@ describe(testName, function () {
     });
 
     it('closes the callback server', function (done) {
+        expect(callbackServer).toBeDefined();
         utils.closeServer(callbackServer, done);
     });
 

--- a/src/test/integration/webhook_https_self_signed_spec.js
+++ b/src/test/integration/webhook_https_self_signed_spec.js
@@ -29,41 +29,44 @@ describe(testName, function () {
 
     var callbackItems = [];
     var postedItems = [];
-    var server;
+    var callbackServer;
 
     it('runs callback server', function (done) {
-        server = utils.startHttpsServer(port, function (string) {
+        callbackServer = utils.startHttpsServer(port, function (string) {
             callbackItems.push(string);
         }, done);
 
     });
 
-    it('posts items', function () {
+    it('posts items', function (done) {
         utils.postItemQ(channelResource)
             .then(function (value) {
-                return postedItem(value, true);
-            }).then(function (value) {
-                return postedItem(value, true);
-            }).then(function (value) {
-                return postedItem(value, true);
-            }).then(function (value) {
-                postedItem(value, false);
-            });
-
-        waitsFor(function () {
-            return callbackItems.length == 4;
-        }, 12000);
-
-        function postedItem(value, post) {
-            postedItems.push(value.body._links.self.href);
-            if (post) {
+                postedItems.push(value.body._links.self.href);
                 return utils.postItemQ(channelResource);
-            }
-        }
+            })
+            .then(function (value) {
+                postedItems.push(value.body._links.self.href);
+                return utils.postItemQ(channelResource);
+            })
+            .then(function (value) {
+                postedItems.push(value.body._links.self.href);
+                return utils.postItemQ(channelResource);
+            })
+            .then(function (value) {
+                postedItems.push(value.body._links.self.href);
+                done();
+            });
     });
 
-    it('closes server and verifies items', function () {
-        server.close();
+    it('waits for data', function (done) {
+        utils.waitForData(callbackItems, postedItems, done);
+    });
+
+    it('closes the callback server', function (done) {
+        utils.closeServer(callbackServer, done);
+    });
+
+    it('verifies we got what we expected through the callback', function () {
         expect(callbackItems.length).toBe(4);
         expect(postedItems.length).toBe(4);
         for (var i = 0; i < callbackItems.length; i++) {
@@ -71,8 +74,7 @@ describe(testName, function () {
             expect(parse.uris[0]).toBe(postedItems[i]);
             expect(parse.name).toBe(webhookName);
         }
-
-    })
+    });
 
 });
 

--- a/src/test/integration/webhook_lifecycle_offset_spec.js
+++ b/src/test/integration/webhook_lifecycle_offset_spec.js
@@ -25,7 +25,7 @@ var webhookConfig = {
  */
 describe(testName, function () {
     utils.createChannel(channelName, false, testName);
-    utils.timeout(1000);
+    utils.itSleeps(1000);
     utils.addItem(channelResource);
     utils.addItem(channelResource);
 

--- a/src/test/integration/webhook_lifecycle_offset_spec.js
+++ b/src/test/integration/webhook_lifecycle_offset_spec.js
@@ -36,7 +36,8 @@ describe(testName, function () {
     var postedItems = [];
 
     it('runs callback server', function (done) {
-        callbackServer = utils.startHttpsServer(port, function (string) {
+        callbackServer = utils.startHttpServer(port, function (string) {
+            console.log('called webhook ' + webhookName + ' ' + string);
             callbackItems.push(string);
         }, done);
 

--- a/src/test/integration/webhook_lifecycle_offset_spec.js
+++ b/src/test/integration/webhook_lifecycle_offset_spec.js
@@ -31,47 +31,53 @@ describe(testName, function () {
 
     utils.putWebhook(webhookName, webhookConfig, 201, testName);
 
-    it('runs callback server', function () {
-        var callbackItems = [];
-        var postedItems = [];
+    var callbackServer;
+    var callbackItems = [];
+    var postedItems = [];
 
-        utils.startServer(port, function (string) {
-            console.log('called webhook ' + webhookName + ' ' + string);
+    it('runs callback server', function (done) {
+        callbackServer = utils.startHttpsServer(port, function (string) {
             callbackItems.push(string);
-        });
+        }, done);
 
+    });
+
+    it('posts items', function (done) {
         utils.postItemQ(channelResource)
             .then(function (value) {
-                return postedItem(value, true);
-            }).then(function (value) {
-                return postedItem(value, true);
-            }).then(function (value) {
-                return postedItem(value, true);
-            }).then(function (value) {
-                postedItem(value, false);
-            });
-
-        waitsFor(function () {
-            return callbackItems.length == 4;
-        }, 11997);
-
-        utils.closeServer(function () {
-            expect(callbackItems.length).toBe(4);
-            expect(postedItems.length).toBe(4);
-            for (var i = 0; i < callbackItems.length; i++) {
-                var parse = JSON.parse(callbackItems[i]);
-                expect(parse.uris[0]).toBe(postedItems[i]);
-                expect(parse.name).toBe(webhookName);
-            }
-        }, testName);
-
-        function postedItem(value, post) {
-            postedItems.push(value.body._links.self.href);
-            if (post) {
+                postedItems.push(value.body._links.self.href);
                 return utils.postItemQ(channelResource);
-            }
-        }
+            })
+            .then(function (value) {
+                postedItems.push(value.body._links.self.href);
+                return utils.postItemQ(channelResource);
+            })
+            .then(function (value) {
+                postedItems.push(value.body._links.self.href);
+                return utils.postItemQ(channelResource);
+            })
+            .then(function (value) {
+                postedItems.push(value.body._links.self.href);
+                done();
+            });
+    });
 
+    it('waits for data', function (done) {
+        utils.waitForData(callbackItems, postedItems, done);
+    });
+
+    it('closes the callback server', function (done) {
+        utils.closeServer(callbackServer, done);
+    });
+
+    it('verifies we got what we expected through the callback', function () {
+        expect(callbackItems.length).toBe(4);
+        expect(postedItems.length).toBe(4);
+        for (var i = 0; i < callbackItems.length; i++) {
+            var parse = JSON.parse(callbackItems[i]);
+            expect(parse.uris[0]).toBe(postedItems[i]);
+            expect(parse.name).toBe(webhookName);
+        }
     });
 
 });

--- a/src/test/integration/webhook_lifecycle_offset_spec.js
+++ b/src/test/integration/webhook_lifecycle_offset_spec.js
@@ -67,6 +67,7 @@ describe(testName, function () {
     });
 
     it('closes the callback server', function (done) {
+        expect(callbackServer).toBeDefined();
         utils.closeServer(callbackServer, done);
     });
 

--- a/src/test/integration/webhook_lifecycle_past_spec.js
+++ b/src/test/integration/webhook_lifecycle_past_spec.js
@@ -23,7 +23,7 @@ var callbackUrl = callbackDomain + ':' + port + '/';
 describe(testName, function () {
     utils.createChannel(channelName, false, testName);
 
-    utils.timeout(1000);
+    utils.itSleeps(1000);
     var postedItems = [];
     var firstItem;
 

--- a/src/test/integration/webhook_lifecycle_past_spec.js
+++ b/src/test/integration/webhook_lifecycle_past_spec.js
@@ -54,7 +54,7 @@ describe(testName, function () {
     var callbackItems;
 
     it('starts a callback server', function (done) {
-        callbackServer = this.startHttpServer(port, function (string) {
+        callbackServer = utils.startHttpServer(port, function (string) {
             console.log('called webhook ' + webhookName + ' ' + string);
             callbackItems.push(string);
         }, done);

--- a/src/test/integration/webhook_lifecycle_past_spec.js
+++ b/src/test/integration/webhook_lifecycle_past_spec.js
@@ -85,6 +85,7 @@ describe(testName, function () {
     });
 
     it('closes the first callback server', function (done) {
+        expect(callbackServer).toBeDefined();
         utils.closeServer(callbackServer, done);
     });
     

--- a/src/test/integration/webhook_lifecycle_past_spec.js
+++ b/src/test/integration/webhook_lifecycle_past_spec.js
@@ -51,7 +51,7 @@ describe(testName, function () {
     }, 201, testName);
     
     var callbackServer;
-    var callbackItems;
+    var callbackItems = [];
 
     it('starts a callback server', function (done) {
         callbackServer = utils.startHttpServer(port, function (string) {

--- a/src/test/integration/webhook_lifecycle_past_spec.js
+++ b/src/test/integration/webhook_lifecycle_past_spec.js
@@ -27,12 +27,9 @@ describe(testName, function () {
     var postedItems = [];
     var firstItem;
 
-    function postedItem(value, post) {
+    function addPostedItem(value) {
         postedItems.push(value.body._links.self.href);
         console.log('postedItems', postedItems);
-        if (post) {
-            return utils.postItemQ(channelResource);
-        }
     }
 
     it('posts initial items ' + channelResource, function (done) {
@@ -40,72 +37,65 @@ describe(testName, function () {
             .then(function (value) {
                 firstItem = value.body._links.self.href;
                 return utils.postItemQ(channelResource);
-            }).then(function (value) {
-                postedItem(value, false);
+            })
+            .then(function (value) {
+                addPostedItem(value);
                 done();
             });
     });
 
-    it('creates webhook ' + webhookName, function (done) {
-        var webhookConfig = {
-            callbackUrl: callbackUrl,
-            channelUrl: channelResource,
-            startItem: firstItem
-        };
-        var webhookResource = utils.getWebhookUrl() + "/" + webhookName;
-        console.log('creating webhook', webhookName, webhookConfig);
-        request.put({
-                url: webhookResource,
-                headers: {"Content-Type": "application/json"},
-                body: JSON.stringify(webhookConfig)
-            },
-            function (err, response, body) {
-                expect(err).toBeNull();
-                expect(response.statusCode).toBe(201);
-                expect(response.headers.location).toBe(webhookResource);
-                var parse = utils.parseJson(response, testName);
-                expect(parse.callbackUrl).toBe(webhookConfig.callbackUrl);
-                expect(parse.channelUrl).toBe(webhookConfig.channelUrl);
-                expect(parse.name).toBe(webhookName);
-                done();
-            });
-    });
+    utils.putWebhook(webhookName, {
+        callbackUrl: callbackUrl,
+        channelUrl: channelResource,
+        startItem: firstItem
+    }, 201, testName);
+    
+    var callbackServer;
+    var callbackItems;
 
-
-    it('runs callback server webhook:' + webhookName + ' channel:' + channelName, function () {
-        var callbackItems = [];
-
-        utils.startServer(port, function (string) {
+    it('starts a callback server', function (done) {
+        callbackServer = this.startHttpServer(port, function (string) {
             console.log('called webhook ' + webhookName + ' ' + string);
             callbackItems.push(string);
-        });
-
+        }, done);
+    });
+    
+    it('inserts items', function (done) {
         utils.postItemQ(channelResource)
             .then(function (value) {
-                return postedItem(value, true);
-            }).then(function (value) {
-                return postedItem(value, true);
-            }).then(function (value) {
-                return postedItem(value, true);
-            }).then(function (value) {
-                postedItem(value, false);
+                addPostedItem(value);
+                return utils.postItemQ(channelResource);
+            })
+            .then(function (value) {
+                addPostedItem(value);
+                return utils.postItemQ(channelResource);
+            })
+            .then(function (value) {
+                addPostedItem(value);
+                return utils.postItemQ(channelResource);
+            })
+            .then(function (value) {
+                addPostedItem(value);
+                done();
             });
+    });
 
-        waitsFor(function () {
-            return callbackItems.length == 5;
-        }, 11997);
+    it('waits for data', function (done) {
+        utils.waitForData(callbackItems, postedItems, done);
+    });
 
-        utils.closeServer(function () {
-            expect(callbackItems.length).toBe(5);
-            expect(postedItems.length).toBe(5);
-            for (var i = 0; i < callbackItems.length; i++) {
-                var parse = JSON.parse(callbackItems[i]);
-                expect(parse.uris[0]).toBe(postedItems[i]);
-                expect(parse.name).toBe(webhookName);
-            }
-        }, testName);
-
+    it('closes the first callback server', function (done) {
+        utils.closeServer(callbackServer, done);
+    });
+    
+    it('verifies we got what we expected through the callback', function () {
+        expect(callbackItems.length).toBe(5);
+        expect(postedItems.length).toBe(5);
+        for (var i = 0; i < callbackItems.length; i++) {
+            var parse = JSON.parse(callbackItems[i]);
+            expect(parse.uris[0]).toBe(postedItems[i]);
+            expect(parse.name).toBe(webhookName);
+        }
     });
 
 });
-

--- a/src/test/integration/webhook_lifecycle_past_spec.js
+++ b/src/test/integration/webhook_lifecycle_past_spec.js
@@ -44,12 +44,31 @@ describe(testName, function () {
             });
     });
 
-    utils.putWebhook(webhookName, {
-        callbackUrl: callbackUrl,
-        channelUrl: channelResource,
-        startItem: firstItem
-    }, 201, testName);
-    
+    it('creates a webhook', function (done) {
+        var url = utils.getWebhookUrl() + '/' + webhookName;
+        var headers = {'Content-Type': 'application/json'};
+        var body = {
+            callbackUrl: callbackUrl,
+            channelUrl: channelResource,
+            startItem: firstItem
+        };
+
+        utils.httpPut(url, headers, body)
+            .then(function (response) {
+                expect(response.statusCode).toBe(201);
+                expect(response.headers.location).toBe(url);
+                expect(response.body.callbackUrl).toBe(callbackUrl);
+                expect(response.body.channelUrl).toBe(channelResource);
+                expect(response.body.name).toBe(webhookName);
+            })
+            .catch(function (error) {
+                expect(error).toBeNull();
+            })
+            .fin(function () {
+                done();
+            });
+    });
+
     var callbackServer;
     var callbackItems = [];
 

--- a/src/test/integration/webhook_lifecycle_pause_spec_disabled.js
+++ b/src/test/integration/webhook_lifecycle_pause_spec_disabled.js
@@ -111,6 +111,7 @@ describe(testName, function () {
     utils.itSleeps(2000);
     
     it('closes the callback server', function (done) {
+        expect(callbackServer).toBeDefined();
         utils.closeServer(callbackServer, done);
     });
     

--- a/src/test/integration/webhook_lifecycle_pause_spec_disabled.js
+++ b/src/test/integration/webhook_lifecycle_pause_spec_disabled.js
@@ -74,7 +74,9 @@ describe(testName, function () {
         }, "2 callbacks collected", 15 * 1000);
 
     }, 15 * 1000);
-    utils.timeout(2000);
+    
+    utils.itSleeps(2000);
+
     it('expects 2 items collected', function () {
         expect(callbackItems.length).toBe(2);
     });
@@ -106,7 +108,6 @@ describe(testName, function () {
 
     console.log("###### resuming web hook");
     webhook = utils.putWebhook(webhookName, webhookConfig, 200, testName);
-    utils.timeout(2000);
     
     utils.itSleeps(2000);
     

--- a/src/test/integration/webhook_lifecycle_previous_spec.js
+++ b/src/test/integration/webhook_lifecycle_previous_spec.js
@@ -23,7 +23,7 @@ var callbackUrl = callbackDomain + ':' + port + '/';
 describe(testName, function () {
     utils.createChannel(channelName, false, testName);
 
-    utils.timeout(1000);
+    utils.itSleeps(1000);
     var postedItems = [];
     var firstItem;
 

--- a/src/test/integration/webhook_lifecycle_previous_spec.js
+++ b/src/test/integration/webhook_lifecycle_previous_spec.js
@@ -27,12 +27,9 @@ describe(testName, function () {
     var postedItems = [];
     var firstItem;
 
-    function postedItem(value, post) {
+    function addPostedItem(value) {
         postedItems.push(value.body._links.self.href);
         console.log('postedItems', postedItems);
-        if (post) {
-            return utils.postItemQ(channelResource);
-        }
     }
 
     it('posts initial items ' + channelResource, function (done) {
@@ -40,13 +37,14 @@ describe(testName, function () {
             .then(function (value) {
                 firstItem = value.body._links.self.href;
                 return utils.postItemQ(channelResource);
-            }).then(function (value) {
-            postedItem(value, false);
-            return utils.sleepQ(6 * 1000);
-        }).then(function (value) {
-            done();
-        });
+            })
+            .then(function (value) {
+                addPostedItem(value);
+                done();
+            });
     });
+    
+    utils.itSleeps(6000);
 
     it('creates webhook ' + webhookName, function (done) {
         var webhookConfig = {
@@ -84,14 +82,20 @@ describe(testName, function () {
 
         utils.postItemQ(channelResource)
             .then(function (value) {
-                return postedItem(value, true);
-            }).then(function (value) {
-            return postedItem(value, true);
-        }).then(function (value) {
-            return postedItem(value, true);
-        }).then(function (value) {
-            postedItem(value, false);
-        });
+                addPostedItem(value);
+                return utils.postItemQ(channelResource);
+            })
+            .then(function (value) {
+                addPostedItem(value);
+                return utils.postItemQ(channelResource);
+            })
+            .then(function (value) {
+                addPostedItem(value);
+                return utils.postItemQ(channelResource);
+            })
+            .then(function (value) {
+                addPostedItem(value);
+            });
 
         waitsFor(function () {
             return callbackItems.length == 5;

--- a/src/test/integration/webhook_lifecycle_previous_spec.js
+++ b/src/test/integration/webhook_lifecycle_previous_spec.js
@@ -56,7 +56,7 @@ describe(testName, function () {
     var callbackItems = [];
 
     it('starts a callback server', function (done) {
-        callbackServer = this.startHttpServer(port, function (string) {
+        callbackServer = utils.startHttpServer(port, function (string) {
             console.log('called webhook ' + webhookName + ' ' + string);
             callbackItems.push(string);
         }, done);

--- a/src/test/integration/webhook_lifecycle_previous_spec.js
+++ b/src/test/integration/webhook_lifecycle_previous_spec.js
@@ -87,6 +87,7 @@ describe(testName, function () {
     });
 
     it('closes the first callback server', function (done) {
+        expect(callbackServer).toBeDefined();
         utils.closeServer(callbackServer, done);
     });
 

--- a/src/test/integration/webhook_lifecycle_spec.js
+++ b/src/test/integration/webhook_lifecycle_spec.js
@@ -63,6 +63,7 @@ describe(testName, function () {
     });
 
     it('closes the first callback server', function (done) {
+        expect(callbackServer).toBeDefined();
         utils.closeServer(callbackServer, done);
     });
 

--- a/src/test/integration/webhook_lifecycle_spec.js
+++ b/src/test/integration/webhook_lifecycle_spec.js
@@ -23,6 +23,8 @@ var webhookConfig = {
  * 5 - verify that the records are returned within delta time
  */
 describe(testName, function () {
+
+    var callbackServer;
     var callbackItems = [];
     var postedItems = [];
 
@@ -30,43 +32,48 @@ describe(testName, function () {
 
     utils.putWebhook(webhookName, webhookConfig, 201, testName);
 
-    it('runs callback server', function () {
-        utils.startServer(port, function (string) {
+    it('starts a callback server', function (done) {
+        callbackServer = this.startHttpServer(port, function (string) {
             callbackItems.push(string);
-        });
+        }, done);
+    });
 
+    it('inserts items', function (done) {
         utils.postItemQ(channelResource)
             .then(function (value) {
-                return postedItem(value, true);
-            }).then(function (value) {
-                return postedItem(value, true);
-            }).then(function (value) {
-                return postedItem(value, true);
-            }).then(function (value) {
-                postedItem(value, false);
-            });
-
-        waitsFor(function () {
-            return callbackItems.length == 4;
-        }, 9999);
-
-        utils.closeServer(function () {
-            expect(callbackItems.length).toBe(4);
-            expect(postedItems.length).toBe(4);
-            for (var i = 0; i < callbackItems.length; i++) {
-                var parse = JSON.parse(callbackItems[i]);
-                expect(parse.uris[0]).toBe(postedItems[i]);
-                expect(parse.name).toBe(webhookName);
-            }
-        }, testName);
-
-        function postedItem(value, post) {
-            postedItems.push(value.body._links.self.href);
-            if (post) {
+                postedItems.push(value.body._links.self.href);
                 return utils.postItemQ(channelResource);
-            }
-        }
+            })
+            .then(function (value) {
+                postedItems.push(value.body._links.self.href);
+                return utils.postItemQ(channelResource);
+            })
+            .then(function (value) {
+                postedItems.push(value.body._links.self.href);
+                return utils.postItemQ(channelResource);
+            })
+            .then(function (value) {
+                postedItems.push(value.body._links.self.href);
+                done();
+            });
+    });
 
+    it('waits for data', function (done) {
+        utils.waitForData(callbackItems, postedItems, done);
+    });
+
+    it('closes the first callback server', function (done) {
+        utils.closeServer(callbackServer, done);
+    });
+
+    it('verifies we got what we expected through the callback', function () {
+        expect(callbackItems.length).toBe(4);
+        expect(postedItems.length).toBe(4);
+        for (var i = 0; i < callbackItems.length; i++) {
+            var parse = JSON.parse(callbackItems[i]);
+            expect(parse.uris[0]).toBe(postedItems[i]);
+            expect(parse.name).toBe(webhookName);
+        }
     });
 
     it('verifies lastCompleted', function (done) {
@@ -92,4 +99,3 @@ describe(testName, function () {
     })
 
 });
-

--- a/src/test/integration/webhook_lifecycle_spec.js
+++ b/src/test/integration/webhook_lifecycle_spec.js
@@ -33,7 +33,7 @@ describe(testName, function () {
     utils.putWebhook(webhookName, webhookConfig, 201, testName);
 
     it('starts a callback server', function (done) {
-        callbackServer = this.startHttpServer(port, function (string) {
+        callbackServer = utils.startHttpServer(port, function (string) {
             callbackItems.push(string);
         }, done);
     });

--- a/src/test/integration/webhook_list_spec.js
+++ b/src/test/integration/webhook_list_spec.js
@@ -64,8 +64,8 @@ describe(testName, function () {
                 done();
             });
     });
-    
-    var foundWebhookHrefs = [];
+
+    var foundURLs = [];
 
     it('gets a list of the webhooks', function (done) {
         var url = webhookUrl;
@@ -74,16 +74,10 @@ describe(testName, function () {
         utils.httpGet(url, headers)
             .then(function (response) {
                 expect(response.statusCode).toBe(200);
-                expect(response.body._links.self.href).toBe(webhookUrl);
-                var items = response.body._links.groups || response.body._links.webhooks;
-                for (var i = 0; i < items.length; ++i) {
-                    if (item.name === webhookName1 || item.name === webhookName2) {
-                        foundWebhookHrefs.push(item.href);
-                    }
-                }
-                expect(foundWebhookHrefs.length).toEqual(2);
-                expect(foundWebhookHrefs).toContain(firstWebhookURL);
-                expect(foundWebhookHrefs).toContain(secondWebhookURL);
+                expect(response.body._links.self.href).toEqual(webhookUrl);
+                foundURLs = (response.body._links.groups || response.body._links.webhooks)
+                    .map(function (item) { return item.href })
+                    .filter(function (href) { return href == firstWebhookURL || href == secondWebhookURL });
             })
             .catch(function (error) {
                 expect(error).toBeNull();
@@ -91,6 +85,12 @@ describe(testName, function () {
             .fin(function () {
                 done();
             });
+    });
+
+    it('verifies we found the correct URLs', function () {
+        expect(foundURLs.length).toEqual(2);
+        expect(foundURLs).toContain(firstWebhookURL);
+        expect(foundURLs).toContain(secondWebhookURL);
     });
 
     utils.deleteWebhook(webhookName1);

--- a/src/test/integration/webhook_no_startItem_spec.js
+++ b/src/test/integration/webhook_no_startItem_spec.js
@@ -17,8 +17,9 @@ describe(testName, function () {
     utils.createChannel(channelName, channelUrl, testName);
     utils.putWebhook(channelName, webhookConfig, 201, testName);
 
+    utils.itSleeps(10000);
+    
     it('gets webhook ' + channelName, function (done) {
-        utils.sleep(10000);
         request.get({
                 url: gUrl,
                 headers: {"Content-Type": "application/json"}

--- a/src/test/integration/websocket_spec.js
+++ b/src/test/integration/websocket_spec.js
@@ -44,7 +44,7 @@ describe(__filename, function () {
         });
 
         it('waits for data', function (done) {
-            waitForMessages(receivedMessages, itemURLs, done);
+            utils.waitForData(receivedMessages, itemURLs, done);
         });
 
         it('verifies the correct data was received', function () {
@@ -107,7 +107,7 @@ describe(__filename, function () {
         });
 
         it('waits for data', function (done) {
-            waitForMessages(receivedMessages, itemURLs, done);
+            utils.waitForData(receivedMessages, itemURLs, done);
         });
 
         it('verifies the correct data was received', function () {
@@ -171,7 +171,7 @@ describe(__filename, function () {
         });
 
         it('waits for data', function (done) {
-            waitForMessages(receivedMessages, itemURLs, done);
+            utils.waitForData(receivedMessages, itemURLs, done);
         });
 
         it('verifies the correct data was received', function () {
@@ -236,7 +236,7 @@ describe(__filename, function () {
         });
 
         it('waits for data', function (done) {
-            waitForMessages(receivedMessages, itemURLs, done);
+            utils.waitForData(receivedMessages, itemURLs, done);
         });
 
         it('verifies the correct data was received', function () {
@@ -302,7 +302,7 @@ describe(__filename, function () {
         });
 
         it('waits for data', function (done) {
-            waitForMessages(receivedMessages, itemURLs, done);
+            utils.waitForData(receivedMessages, itemURLs, done);
         });
 
         it('verifies the correct data was received', function () {
@@ -359,7 +359,7 @@ describe(__filename, function () {
         });
 
         it('waits for data', function (done) {
-            waitForMessages(receivedMessages, itemURLs.slice(1), done);
+            utils.waitForData(receivedMessages, itemURLs.slice(1), done);
         });
 
         it('verifies the correct data was received', function () {
@@ -382,17 +382,3 @@ describe(__filename, function () {
     });
 
 });
-
-function waitForMessages(actual, expected, done) {
-    expect(actual).isPrototypeOf(Array);
-    expect(expected).isPrototypeOf(Array);
-    setTimeout(function () {
-        if (actual.length !== expected.length) {
-            waitForMessages(actual, expected, done);
-        } else {
-            console.log('expected:', expected);
-            console.log('actual:', actual);
-            done();
-        }
-    }, 500);
-}


### PR DESCRIPTION
This drops ```jasmine-node``` in favor of pure Jasmine. It also upgrades from Jasmine 1.3 to 2.6 which has some breaking API changes. Notably the reporter hooks and the removal of ```runs``` and ```waitFor```.

The breaking API changes forced me to modify some tests so its important we're sure the tests do the same thing they did before (for better or worse). A common pattern you will see is using individual test specs to control the synchronous operations.

This also makes a little progress towards #832 with a proper ```package.json``` file for dependencies. No NPM scripts yet, that will come in a future PR. This also means no more ```install.sh``` script.

Here is a link to a transient Jenkins job I made for this new world:
https://ddt-jenkins.pdx.prod.flightstats.io/job/zander-integration-tests

**Merging this PR will require tweaks to the Jenkins jobs. Ping me when you're about to merge it so I can coordinate updating the jobs**