### PR TITLE
update run to add -XX:+ExitOnOutOfMemoryError

### DIFF
--- a/docker/run
+++ b/docker/run
@@ -31,6 +31,7 @@ JAVA_OPTS="
  -XX:NewSize=$MIN_NEW
  -XX:+UseG1GC
  -XX:MaxGCPauseMillis=100
+ -XX:+ExitOnOutOfMemoryError
  -Dsun.rmi.dgc.client.gcInterval=300000
  -Dsun.rmi.dgc.server.gcInterval=300000
  -agentlib:jdwp=transport=dt_socket,address=$DEBUG_PORT,server=y,suspend=n


### PR DESCRIPTION
[2:30 PM] Greg Moulliet: maybe we should try '-XX:+ExitOnOutOfMemoryError'
[2:30 PM] Greg Moulliet: because nothing good can happen after the OOM