### PR TITLE
Spoke store enforcer

### DIFF
--- a/src/main/java/com/flightstats/hub/app/ClusterHubBindings.java
+++ b/src/main/java/com/flightstats/hub/app/ClusterHubBindings.java
@@ -9,6 +9,7 @@ import com.flightstats.hub.dao.aws.*;
 import com.flightstats.hub.model.ChannelConfig;
 import com.flightstats.hub.spoke.RemoteSpokeStore;
 import com.flightstats.hub.spoke.SpokeContentDao;
+import com.flightstats.hub.spoke.SpokeStoreEnforcer;
 import com.flightstats.hub.spoke.SpokeTtlEnforcer;
 import com.flightstats.hub.webhook.Webhook;
 import com.google.inject.AbstractModule;
@@ -57,6 +58,7 @@ class ClusterHubBindings extends AbstractModule {
         bind(SpokeTtlEnforcer.class).asEagerSingleton();
         bind(DocumentationDao.class).to(S3DocumentationDao.class).asEagerSingleton();
         bind(SpokeDecommissionManager.class).asEagerSingleton();
+        bind(SpokeStoreEnforcer.class).asEagerSingleton();
     }
 
     @Inject

--- a/src/main/java/com/flightstats/hub/dao/file/FileUtil.java
+++ b/src/main/java/com/flightstats/hub/dao/file/FileUtil.java
@@ -104,7 +104,7 @@ public class FileUtil {
             Path path = paths.get(i);
 
             if (!Files.exists(path)) {
-                logger.info("skipping, already moved {}", path);
+                logger.debug("skipping, already moved {}", path);
                 continue;
             }
 
@@ -112,7 +112,7 @@ public class FileUtil {
             Path proposedPath = new File(destination.toString(), relativePath.toString()).toPath();
 
             if (Files.exists(proposedPath)) {
-                logger.info("skipping, already exists {}", proposedPath);
+                logger.debug("skipping, already exists {}", proposedPath);
                 continue;
             }
 

--- a/src/main/java/com/flightstats/hub/dao/file/FileUtil.java
+++ b/src/main/java/com/flightstats/hub/dao/file/FileUtil.java
@@ -108,6 +108,11 @@ public class FileUtil {
                 continue;
             }
 
+            if (path.startsWith(destination)) {
+                logger.debug("skipping, is destination {}", path);
+                continue;
+            }
+
             Path relativePath = source.relativize(path);
             Path proposedPath = new File(destination.toString(), relativePath.toString()).toPath();
 

--- a/src/main/java/com/flightstats/hub/dao/file/FileUtil.java
+++ b/src/main/java/com/flightstats/hub/dao/file/FileUtil.java
@@ -86,7 +86,7 @@ public class FileUtil {
     public static void createDirectory(String directoryPath) throws IOException {
         try {
             Path path = Paths.get(directoryPath);
-            Files.createDirectory(path);
+            Files.createDirectories(path);
         } catch (IOException e) {
             logger.warn("unable to create directory {}", directoryPath);
             throw e;

--- a/src/main/java/com/flightstats/hub/dao/file/FileUtil.java
+++ b/src/main/java/com/flightstats/hub/dao/file/FileUtil.java
@@ -96,8 +96,8 @@ public class FileUtil {
     public static void mergeDirectories(String from, String to) throws IOException {
         logger.info("merging {} into {}", from, to);
 
-        Path source = Paths.get(from);
-        Path destination = Paths.get(to);
+        Path source = Paths.get(from).toAbsolutePath();
+        Path destination = Paths.get(to).toAbsolutePath();
 
         List<Path> paths = Files.walk(source).collect(Collectors.toList());
         for (int i = 0; i < paths.size(); ++i) {

--- a/src/main/java/com/flightstats/hub/dao/file/FileUtil.java
+++ b/src/main/java/com/flightstats/hub/dao/file/FileUtil.java
@@ -87,6 +87,9 @@ public class FileUtil {
         try {
             Path source = Paths.get(from);
             Path destination = Paths.get(to);
+            if (source.equals(destination)) {
+                logger.info("ignoring move request since the source and destination are the same");
+            }
             Files.move(source, destination, StandardCopyOption.ATOMIC_MOVE);
         } catch (IOException e) {
             logger.warn("unable to move {} to {}", from, to);

--- a/src/main/java/com/flightstats/hub/dao/file/FileUtil.java
+++ b/src/main/java/com/flightstats/hub/dao/file/FileUtil.java
@@ -9,14 +9,16 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
 
-class FileUtil {
+public class FileUtil {
 
     private final static Logger logger = LoggerFactory.getLogger(FileUtil.class);
 
@@ -74,5 +76,31 @@ class FileUtil {
         Path path = Paths.get(filepath);
         File file = path.toFile();
         return FileUtils.deleteQuietly(file);
+    }
+
+    public static boolean directoryExists(String directoryPath) {
+        Path path = Paths.get(directoryPath);
+        return Files.exists(path);
+    }
+
+    public static void move(String from, String to) throws IOException {
+        try {
+            Path source = Paths.get(from);
+            Path destination = Paths.get(to);
+            Files.move(source, destination, StandardCopyOption.ATOMIC_MOVE);
+        } catch (IOException e) {
+            logger.warn("unable to move {} to {}", from, to);
+            throw e;
+        }
+    }
+
+    public static void createDirectory(String directoryPath) throws IOException {
+        try {
+            Path path = Paths.get(directoryPath);
+            Files.createDirectory(path);
+        } catch (IOException e) {
+            logger.warn("unable to create directory {}", directoryPath);
+            throw e;
+        }
     }
 }

--- a/src/main/java/com/flightstats/hub/spoke/SpokeStoreEnforcer.java
+++ b/src/main/java/com/flightstats/hub/spoke/SpokeStoreEnforcer.java
@@ -1,0 +1,67 @@
+package com.flightstats.hub.spoke;
+
+import com.flightstats.hub.app.HubProperties;
+import com.flightstats.hub.app.HubServices;
+import com.google.common.util.concurrent.AbstractIdleService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.util.Arrays;
+
+import static com.flightstats.hub.dao.file.FileUtil.createDirectory;
+import static com.flightstats.hub.dao.file.FileUtil.directoryExists;
+import static com.flightstats.hub.dao.file.FileUtil.move;
+
+@Singleton
+public class SpokeStoreEnforcer {
+
+    private final static Logger logger = LoggerFactory.getLogger(SpokeStoreEnforcer.class);
+    private final static String spokePath = HubProperties.getSpokePath();
+    private final static String previousSpokePaths = HubProperties.getProperty("spoke.previousPaths", "");
+
+    @Inject
+    public SpokeStoreEnforcer() {
+        if (HubProperties.getProperty("spoke.enforceStore", true)) {
+            HubServices.register(new SpokeStoreEnforcerService());
+        }
+    }
+
+    private class SpokeStoreEnforcerService extends AbstractIdleService {
+
+        @Override
+        protected void startUp() throws Exception {
+            logger.info("verifying the spoke store exists");
+            if (directoryExists(spokePath)) {
+                logger.info("spoke store found {}", spokePath);
+            } else {
+                logger.info("looking for spoke stores at previous paths {}", previousSpokePaths);
+                createDirectory(spokePath);
+                Arrays.stream(previousSpokePaths.split(",")).forEach(this::migrate);
+            }
+        }
+
+        private void migrate(String previousPath) {
+            if (directoryExists(previousPath)) {
+                long start = System.currentTimeMillis();
+                try {
+                    logger.info("moving files from {} to {}", previousPath, spokePath);
+                    move(previousPath, spokePath);
+                } catch (IOException e) {
+                    logger.info("ignoring spoke store at {}", previousPath);
+                } finally {
+                    logger.info("move completed in {} ms", (System.currentTimeMillis() - start));
+                }
+            } else {
+                logger.info("no data found {}", previousPath);
+            }
+        }
+
+        @Override
+        protected void shutDown() throws Exception {
+            // do nothing
+        }
+    }
+}

--- a/src/main/java/com/flightstats/hub/spoke/SpokeStoreEnforcer.java
+++ b/src/main/java/com/flightstats/hub/spoke/SpokeStoreEnforcer.java
@@ -52,7 +52,7 @@ public class SpokeStoreEnforcer {
                     FileUtil.delete(previousPath);
                     logger.info("move completed in {} ms", (System.currentTimeMillis() - start));
                 } catch (IOException e) {
-                    logger.info("ignoring spoke store at {}", previousPath);
+                    logger.info("ignoring spoke store at {}", previousPath, e);
                 }
             } else {
                 logger.info("no data found at {}", previousPath);

--- a/src/main/java/com/flightstats/hub/spoke/SpokeStoreEnforcer.java
+++ b/src/main/java/com/flightstats/hub/spoke/SpokeStoreEnforcer.java
@@ -46,14 +46,13 @@ public class SpokeStoreEnforcer {
 
         private void migrate(String previousPath) {
             if (FileUtil.directoryExists(previousPath)) {
-                long start = System.currentTimeMillis();
                 try {
+                    long start = System.currentTimeMillis();
                     FileUtil.mergeDirectories(previousPath, spokePath);
                     FileUtil.delete(previousPath);
+                    logger.info("move completed in {} ms", (System.currentTimeMillis() - start));
                 } catch (IOException e) {
                     logger.info("ignoring spoke store at {}", previousPath);
-                } finally {
-                    logger.info("move completed in {} ms", (System.currentTimeMillis() - start));
                 }
             } else {
                 logger.info("no data found at {}", previousPath);

--- a/src/test/java/com/flightstats/hub/dao/file/FileUtilTest.java
+++ b/src/test/java/com/flightstats/hub/dao/file/FileUtilTest.java
@@ -1,0 +1,60 @@
+package com.flightstats.hub.dao.file;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.util.Comparator;
+
+import static org.junit.Assert.assertTrue;
+
+public class FileUtilTest {
+
+    private final static String CANONICAL_NAME = "com.flightstats.hub.dao.file.FileUtilTest";
+    private final static String ROOT_DIRECTORY = "/tmp/" + CANONICAL_NAME + "-" + Instant.now().getEpochSecond();
+
+    @BeforeClass
+    public static void setup() throws IOException {
+        Path root = Paths.get(ROOT_DIRECTORY);
+        Files.createDirectories(root);
+    }
+
+    @AfterClass
+    public static void teardown() throws IOException {
+        Path root = Paths.get(ROOT_DIRECTORY);
+        Files.walk(root)
+                .sorted(Comparator.reverseOrder())
+                .map(Path::toFile)
+                .forEach(File::delete);
+    }
+
+    @Test
+    public void mergeDirectories() throws IOException {
+        String methodName = new Object() {
+        }.getClass().getEnclosingMethod().getName();
+        String workspace = ROOT_DIRECTORY + "/" + methodName;
+        String from = workspace + "/from";
+        String to = workspace + "/to";
+
+        String payloadOne = "foo/0000/00/00/00/00/00/000/123456abcdef";
+        Path pathA = Paths.get(from + "/" + payloadOne);
+        Files.createDirectories(pathA.getParent());
+        Files.createFile(pathA);
+
+        String payloadTwo = "foo/0000/00/00/00/00/00/000/789012ghijkl";
+        Path pathB = Paths.get(to + "/" + payloadTwo);
+        Files.createDirectories(pathB.getParent());
+        Files.createFile(pathB);
+
+        FileUtil.mergeDirectories(from, to);
+
+        assertTrue(Files.exists(Paths.get(to + "/" + payloadOne)));
+        assertTrue(Files.exists(Paths.get(to + "/" + payloadTwo)));
+    }
+}


### PR DESCRIPTION
Does the following on startup unless ```spoke.enforceStore``` is false (defaults to true):

- Verifies ```spoke.path``` exists on the filesystem
- Looks for ```spoke.previousPaths``` in the config (comma delimited)
- Loops over the previous paths and, if they exist, merges them into the ```spoke.path``` location