### PR TITLE
Assume we're in a clustered environment unless proven otherwise.

### DIFF
--- a/src/test/javascript/integration/webhook_localhost_spec.js
+++ b/src/test/javascript/integration/webhook_localhost_spec.js
@@ -27,7 +27,7 @@ describe(__filename, function () {
                 expect(response.statusCode).toEqual(200);
                 let hubType = response.body.properties['hub.type'];
                 if (hubType !== undefined) {
-                    isClustered = response.body.properties['hub.type'] == 'aws';
+                    isClustered = hubType === 'aws';
                 }
                 console.log('isClustered:', isClustered);
             })

--- a/src/test/javascript/integration/webhook_localhost_spec.js
+++ b/src/test/javascript/integration/webhook_localhost_spec.js
@@ -18,14 +18,17 @@ var webhookResource = utils.getWebhookUrl() + "/" + webhookName;
 
 describe(__filename, function () {
 
-    let isClustered = false;
+    let isClustered = true;
 
     it('determines if this is a single or clustered hub', (done) => {
         let url = `${hubUrlBase}/internal/properties`;
         utils.httpGet(url)
             .then(response => {
                 expect(response.statusCode).toEqual(200);
-                isClustered = response.body.properties['hub.type'] == 'aws';
+                let hubType = response.body.properties['hub.type'];
+                if (hubType !== undefined) {
+                    isClustered = response.body.properties['hub.type'] == 'aws';
+                }
                 console.log('isClustered:', isClustered);
             })
             .catch(error => expect(error).toBeNull())


### PR DESCRIPTION
Now the test should work properly even if the Hub under test doesn't have a ```hub.type``` entry in its config.