### PR TITLE
Better calculation of the oldest item in the write queue

### DIFF
--- a/src/main/java/com/flightstats/hub/dao/aws/S3WriteQueue.java
+++ b/src/main/java/com/flightstats/hub/dao/aws/S3WriteQueue.java
@@ -112,7 +112,7 @@ public class S3WriteQueue {
     private Long getOldest() {
         ChannelContentKey[] array = keys.toArray(new ChannelContentKey[0]);
         Arrays.sort(array);
-        if (array.length != 0) {
+        if (array.length > 0) {
             DateTime then = array[0].getContentKey().getTime();
             DateTime now = DateTime.now(DateTimeZone.UTC);
             try {


### PR DESCRIPTION
First off this _actually_ calculates the oldest item. The previous code had a bug. It also employs cleaner patterns and language mechanisms (e.g. streams). It also is defensive when calculating an item's age so `S3WriteQueue.add` isn't affected by exceptions from the time library.