### PR TITLE
Return the node info as a header

### DIFF
--- a/src/main/java/com/flightstats/hub/app/HubResponseFilter.java
+++ b/src/main/java/com/flightstats/hub/app/HubResponseFilter.java
@@ -1,0 +1,16 @@
+package com.flightstats.hub.app;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class HubResponseFilter implements ContainerResponseFilter {
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+        responseContext.getHeaders().add("Hub-Node", HubHost.getLocalNamePort());
+    }
+
+}

--- a/src/main/java/com/flightstats/hub/webhook/WebhookRetryer.java
+++ b/src/main/java/com/flightstats/hub/webhook/WebhookRetryer.java
@@ -1,6 +1,7 @@
 package com.flightstats.hub.webhook;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.flightstats.hub.app.HubHost;
 import com.flightstats.hub.app.HubProperties;
 import com.flightstats.hub.app.HubProvider;
 import com.flightstats.hub.metrics.ActiveTraces;
@@ -103,6 +104,7 @@ class WebhookRetryer {
             try {
                 response = httpClient.resource(attempt.getWebhook().getCallbackUrl())
                         .type(MediaType.APPLICATION_JSON_TYPE)
+                        .header("Hub-Node", HubHost.getLocalNamePort())
                         .post(ClientResponse.class, payload);
                 attempt.setStatusCode(response.getStatus());
             } catch (ClientHandlerException e) {

--- a/src/test/javascript/integration/http_headers_spec.js
+++ b/src/test/javascript/integration/http_headers_spec.js
@@ -2,6 +2,7 @@ const request = require('request');
 const {
     fromObjectPath,
     getProp,
+    hubClientGet
 } = require('../lib/helpers');
 const {
     getHubUrlBase,
@@ -70,5 +71,13 @@ describe(__filename, function () {
             expect(fromObjectPath(['_links', 'self', 'href'], body)).toBe("https://headers:9000/");
             done();
         });
+    });
+
+    it('returns hub name + port in Hub-Node header', async () => {
+        const deployResponse = await hubClientGet(`${hubUrlBase}/internal/deploy/text`);
+        const nodes = getProp('body', response).split(" ");
+        const rootResponse = await hubClientGet(hubUrlBase);
+        const node = fromObjectPath(['headers', 'Hub-Node'], rootResponse);
+        expect(nodes).toContain(`${node}:8080`);
     });
 });

--- a/src/test/javascript/integration/http_headers_spec.js
+++ b/src/test/javascript/integration/http_headers_spec.js
@@ -75,9 +75,11 @@ describe(__filename, function () {
 
     it('returns hub name + port in Hub-Node header', async () => {
         const deployResponse = await hubClientGet(`${hubUrlBase}/internal/deploy/text`);
-        const nodes = getProp('body', response).split(" ");
+        let nodes = getProp('body', deployResponse) || "";
+        nodes = nodes.split(" ").map(node => `${node}:8080`);
         const rootResponse = await hubClientGet(hubUrlBase);
-        const node = fromObjectPath(['headers', 'Hub-Node'], rootResponse);
-        expect(nodes).toContain(`${node}:8080`);
+        console.log(rootResponse.headers);
+        const node = fromObjectPath(['headers', 'hub-node'], rootResponse);
+        expect(nodes).toContain(node);
     });
 });

--- a/src/test/javascript/integration/http_headers_spec.js
+++ b/src/test/javascript/integration/http_headers_spec.js
@@ -74,9 +74,8 @@ describe(__filename, function () {
     });
 
     it('returns hub name + port in Hub-Node header', async () => {
-        const deployResponse = await hubClientGet(`${hubUrlBase}/internal/deploy/text`);
-        let nodes = getProp('body', deployResponse) || "";
-        nodes = nodes.split(" ").map(node => `${node}:8080`);
+        const deployResponse = await hubClientGet(`${hubUrlBase}/internal/deploy`);
+        let nodes = getProp('body', deployResponse) || [];
         const rootResponse = await hubClientGet(hubUrlBase);
         console.log(rootResponse.headers);
         const node = fromObjectPath(['headers', 'hub-node'], rootResponse);

--- a/src/test/javascript/integration/webhook_header_spec.js
+++ b/src/test/javascript/integration/webhook_header_spec.js
@@ -1,0 +1,100 @@
+const {
+    closeServer,
+    createChannel,
+    deleteWebhook,
+    fromObjectPath,
+    getProp,
+    hubClientGet,
+    hubClientDelete,
+    hubClientPostTestItem,
+    putWebhook,
+    randomChannelName,
+    randomString,
+    startServer,
+    waitForCondition,
+} = require('../lib/helpers');
+const {
+    getCallBackDomain,
+    getCallBackPort,
+    getChannelUrl,
+    getHubUrlBase
+} = require('../lib/config');
+
+const channelUrl = getChannelUrl();
+const callbackDomain = getCallBackDomain();
+const port = getCallBackPort();
+const channelName = randomChannelName();
+const webhookName = randomChannelName();
+const channelResource = `${channelUrl}/${channelName}`;
+const callbackPath = `/${randomString(5)}`;
+const callbackUrl = `${callbackDomain}:${port}${callbackPath}`;
+const webhookConfig = {
+    callbackUrl: callbackUrl,
+    channelUrl: channelResource,
+};
+let createdChannel = false;
+let callbackServer = null;
+const requests = [];
+
+/**
+ * This should:
+ *
+ * 1 - create a channel
+ * 2 - start a server at the endpoint
+ * 3 - create a webhook on that channel
+ * 4 - post items into the channel
+ * 5 - verify the headers on the delivered item
+ */
+
+describe(__filename, function () {
+
+    beforeAll(async () => {
+        const channel = await createChannel(channelName, false);
+        createdChannel = getProp('statusCode', channel) === 201;
+    });
+
+    it('creates the webhook', async () => {
+        const response = await putWebhook(webhookName, webhookConfig);
+        expect(getProp('statusCode', response)).toEqual(201);
+    });
+
+    it('starts a callback server', async () => {
+        const callback = (string, response, request) => {
+            console.log(`item delivered: ${string}`);
+            requests.push(request);
+        };
+        callbackServer = await startServer(port, callback, callbackPath);
+    });
+
+    it('inserts item', async () => {
+        if (!createdChannel) return fail('channel not created in before block');
+        const response = await hubClientPostTestItem(channelResource);
+        expect(getProp('statusCode', response)).toEqual(201);
+        const condition = () => (requests.length > 0);
+        await waitForCondition(condition);
+    });
+
+    it('verifies the headers on the delivered item', async () => {
+        if (requests.length < 1) return fail('no requests to verify');
+        const deployResponse = await hubClientGet(`${getHubUrlBase()}/internal/deploy/text`);
+        let nodes = getProp('body', deployResponse) || "";
+        nodes = nodes.split(" ").map(node => `${node}:8080`);
+        expect(requests.length).toEqual(1);
+        const node = fromObjectPath(['headers', 'hub-node'], requests[0]) || "";
+        expect(nodes).toContain(node);
+    });
+
+    it('closes the callback server', async () => {
+        expect(callbackServer).toBeDefined();
+        await closeServer(callbackServer);
+    });
+
+    it('deletes the webhook', async () => {
+        const response = await deleteWebhook(webhookName);
+        expect(getProp('statusCode', response)).toBe(202);
+    });
+
+    afterAll(async () => {
+        await hubClientDelete(channelResource);
+    });
+});

--- a/src/test/javascript/integration/webhook_header_spec.js
+++ b/src/test/javascript/integration/webhook_header_spec.js
@@ -76,9 +76,8 @@ describe(__filename, function () {
 
     it('verifies the headers on the delivered item', async () => {
         if (requests.length < 1) return fail('no requests to verify');
-        const deployResponse = await hubClientGet(`${getHubUrlBase()}/internal/deploy/text`);
-        let nodes = getProp('body', deployResponse) || "";
-        nodes = nodes.split(" ").map(node => `${node}:8080`);
+        const deployResponse = await hubClientGet(`${getHubUrlBase()}/internal/deploy`);
+        let nodes = getProp('body', deployResponse) || [];
         expect(requests.length).toEqual(1);
         const node = fromObjectPath(['headers', 'hub-node'], requests[0]) || "";
         expect(nodes).toContain(node);

--- a/src/test/javascript/lib/helpers/http-server.js
+++ b/src/test/javascript/lib/helpers/http-server.js
@@ -22,7 +22,7 @@ const startServer = async (port, callback, path = '/', secure, file) => {
         // console.log('request.body', request.body);
         const arr = fromObjectPath(['body', 'uris'], request) || [];
         const str = arr[arr.length - 1] || '';
-        if (callback) callback(str, response);
+        if (callback) callback(str, response, request);
     });
 
     const server = secure ? getHttps(app) : getHttp(app);


### PR DESCRIPTION
REST responses and item's delivered via webhooks now include the following header:

    Hub-Node: <domain>:<port>
