### PR TITLE
Spoke metrics

### DIFF
--- a/src/main/java/com/flightstats/hub/app/ClusterHubBindings.java
+++ b/src/main/java/com/flightstats/hub/app/ClusterHubBindings.java
@@ -53,15 +53,11 @@ class ClusterHubBindings extends AbstractModule {
 
         bind(SpokeTtlEnforcer.class)
                 .annotatedWith(Names.named(SpokeStore.WRITE.name()))
-                .toInstance(new SpokeTtlEnforcer(
-                        HubProperties.getSpokePath(SpokeStore.WRITE),
-                        HubProperties.getSpokeTtlMinutes(SpokeStore.WRITE)));
+                .toInstance(new SpokeTtlEnforcer(SpokeStore.WRITE));
 
         bind(SpokeTtlEnforcer.class)
                 .annotatedWith(Names.named(SpokeStore.READ.name()))
-                .toInstance(new SpokeTtlEnforcer(
-                        HubProperties.getSpokePath(SpokeStore.READ),
-                        HubProperties.getSpokeTtlMinutes(SpokeStore.READ)));
+                .toInstance(new SpokeTtlEnforcer(SpokeStore.READ));
 
         bind(DocumentationDao.class).to(S3DocumentationDao.class).asEagerSingleton();
         bind(SpokeDecommissionManager.class).asEagerSingleton();

--- a/src/main/java/com/flightstats/hub/dao/aws/S3WriteQueue.java
+++ b/src/main/java/com/flightstats/hub/dao/aws/S3WriteQueue.java
@@ -17,9 +17,6 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.Interval;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -111,25 +108,8 @@ public class S3WriteQueue {
         }
     }
 
-    private Long calculateAgeMS(ChannelContentKey key) {
-        DateTime then = key.getContentKey().getTime();
-        DateTime now = DateTime.now(DateTimeZone.UTC);
-        try {
-            if (then.isBefore(now)) {
-                Interval delta = new Interval(then, now);
-                return delta.toDurationMillis();
-            } else {
-                Interval delta = new Interval(now, then);
-                return -delta.toDurationMillis();
-            }
-        } catch (IllegalArgumentException e) {
-            logger.warn("unable to calculate the item's age", e);
-            return null;
-        }
-    }
-
     private void countAge(ChannelContentKey key, String metricName) {
-        Long ageMS = calculateAgeMS(key);
+        Long ageMS = key.getAgeMS();
         if (ageMS != null) {
             metricsService.count(metricName, ageMS, "key:" + key.toString());
         }

--- a/src/main/java/com/flightstats/hub/metrics/PeriodicMetricEmitter.java
+++ b/src/main/java/com/flightstats/hub/metrics/PeriodicMetricEmitter.java
@@ -15,10 +15,10 @@ public class PeriodicMetricEmitter {
     private MetricsService metricsService;
 
     PeriodicMetricEmitter() {
-        HubServices.register(new PeriodicPropertyEmitterService(), HubServices.TYPE.AFTER_HEALTHY_START);
+        HubServices.register(new PeriodicMetricEmitterService(), HubServices.TYPE.AFTER_HEALTHY_START);
     }
 
-    private class PeriodicPropertyEmitterService extends AbstractScheduledService {
+    private class PeriodicMetricEmitterService extends AbstractScheduledService {
 
         @Override
         protected void runOneIteration() {

--- a/src/main/java/com/flightstats/hub/model/ChannelContentKey.java
+++ b/src/main/java/com/flightstats/hub/model/ChannelContentKey.java
@@ -43,19 +43,19 @@ public class ChannelContentKey implements Comparable<ChannelContentKey> {
     }
 
     /**
-     * @param path Expects the format of "/spoke/.+/channelName/yyyy/mm/dd/hh/mm/[ss][sss][hash]"
+     * @param path Expects the format of "/mnt/spoke/.+/channelName/yyyy/mm/dd/hh/mm/[ss][sss][hash]"
      */
     public static ChannelContentKey fromSpokePath(String path) {
         String[] split = path.split("/");
-        String channel = split[3];
-        String year = split[4];
-        String month = split[5];
-        String day = split[6];
-        String hour = split[7];
-        String minute = split[8];
-        String second = StringUtils.substring(split[9], 0, 2);
-        String millisecond = StringUtils.substring(split[9], 2, 5);
-        String hash = StringUtils.substring(split[9], 5);
+        String channel = split[4];
+        String year = split[5];
+        String month = split[6];
+        String day = split[7];
+        String hour = split[8];
+        String minute = split[9];
+        String second = StringUtils.substring(split[10], 0, 2);
+        String millisecond = StringUtils.substring(split[10], 2, 5);
+        String hash = StringUtils.substring(split[10], 5);
         String channelPath = Stream.of(channel, year, month, day, hour, minute, second, millisecond, hash).collect(Collectors.joining("/"));
         return fromChannelPath(channelPath);
     }

--- a/src/main/java/com/flightstats/hub/spoke/SpokeContentDao.java
+++ b/src/main/java/com/flightstats/hub/spoke/SpokeContentDao.java
@@ -66,7 +66,7 @@ public class SpokeContentDao {
         String storePath = "/spoke/" + store.name().toLowerCase();
         logger.trace("getting oldest item from " + storePath);
         // expected result format: YYYY-MM-DD+HH:MM:SS.SSSSSSSSSS /spoke/store/channel/yyyy/mm/dd/hh/mm/ssSSShash
-        String result = Commander.run(new String[]{"find", storePath, "-type f", "-printf '%T+ %p'", "|", "sort", "|", "head", "-n", "1"}, 3);
+        String result = Commander.run(new String[]{"/bin/bash", "-c", "find " + storePath + " -type f -printf '%T+ %p' | sort | head -n 1"}, 3);
         String spokePath = StringUtils.substring(result, 31);
         return ChannelContentKey.fromSpokePath(spokePath);
     }

--- a/src/main/java/com/flightstats/hub/spoke/SpokeContentDao.java
+++ b/src/main/java/com/flightstats/hub/spoke/SpokeContentDao.java
@@ -1,5 +1,6 @@
 package com.flightstats.hub.spoke;
 
+import com.flightstats.hub.app.HubProperties;
 import com.flightstats.hub.exception.ContentTooLargeException;
 import com.flightstats.hub.exception.FailedWriteException;
 import com.flightstats.hub.metrics.ActiveTraces;
@@ -63,9 +64,9 @@ public class SpokeContentDao {
     }
 
     static ChannelContentKey getOldestItem(SpokeStore store) {
-        String storePath = "/spoke/" + store.name().toLowerCase();
+        String storePath = HubProperties.getSpokePath(store);
         logger.trace("getting oldest item from " + storePath);
-        // expected result format: YYYY-MM-DD+HH:MM:SS.SSSSSSSSSS /spoke/store/channel/yyyy/mm/dd/hh/mm/ssSSShash
+        // expected result format: YYYY-MM-DD+HH:MM:SS.SSSSSSSSSS /mnt/spoke/store/channel/yyyy/mm/dd/hh/mm/ssSSShash
         String[] command = new String[]{"/bin/bash", "-c", "find " + storePath + " -type f -printf '%T+ %p\\n' | sort | head -n 1"};
         String result = Commander.run(command, 3);
         String spokePath = StringUtils.substring(result, 31);

--- a/src/main/java/com/flightstats/hub/spoke/SpokeContentDao.java
+++ b/src/main/java/com/flightstats/hub/spoke/SpokeContentDao.java
@@ -72,4 +72,12 @@ public class SpokeContentDao {
         String spokePath = StringUtils.substring(result, 31);
         return ChannelContentKey.fromSpokePath(spokePath);
     }
+
+    static long getNumberOfItems(SpokeStore spokeStore) {
+        String storePath = HubProperties.getSpokePath(spokeStore);
+        logger.trace("getting the total number of items in " + storePath);
+        String[] command = new String[]{"/bin/bash", "-c", "find " + storePath + " -type f | wc -l"};
+        String result = Commander.run(command, 1);
+        return Long.valueOf(result);
+    }
 }

--- a/src/main/java/com/flightstats/hub/spoke/SpokeContentDao.java
+++ b/src/main/java/com/flightstats/hub/spoke/SpokeContentDao.java
@@ -5,8 +5,11 @@ import com.flightstats.hub.exception.FailedWriteException;
 import com.flightstats.hub.metrics.ActiveTraces;
 import com.flightstats.hub.metrics.Traces;
 import com.flightstats.hub.model.BulkContent;
+import com.flightstats.hub.model.ChannelContentKey;
 import com.flightstats.hub.model.Content;
 import com.flightstats.hub.model.ContentKey;
+import com.flightstats.hub.util.Commander;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,5 +60,13 @@ public class SpokeContentDao {
             logger.error("unable to write " + channelName, e);
             throw e;
         }
+    }
+
+    static ChannelContentKey getOldestItem(SpokeStore store) {
+        String storePath = "/spoke/" + store.name().toLowerCase();
+        // expected result format: YYYY-MM-DD+HH:MM:SS.SSSSSSSSSS /spoke/store/channel/yyyy/mm/dd/hh/mm/ssSSShash
+        String result = Commander.run(new String[]{"find", storePath, "-type", "f", "-printf", "'%T+ %p\n'", "|", "sort", "|", "head", "-n", "1"}, 3);
+        String spokePath = StringUtils.substring(result, 31);
+        return ChannelContentKey.fromSpokePath(spokePath);
     }
 }

--- a/src/main/java/com/flightstats/hub/spoke/SpokeContentDao.java
+++ b/src/main/java/com/flightstats/hub/spoke/SpokeContentDao.java
@@ -64,8 +64,10 @@ public class SpokeContentDao {
 
     static ChannelContentKey getOldestItem(SpokeStore store) {
         String storePath = "/spoke/" + store.name().toLowerCase();
+        logger.trace("getting oldest item from " + storePath);
         // expected result format: YYYY-MM-DD+HH:MM:SS.SSSSSSSSSS /spoke/store/channel/yyyy/mm/dd/hh/mm/ssSSShash
         String result = Commander.run(new String[]{"find", storePath, "-type", "f", "-printf", "'%T+ %p\n'", "|", "sort", "|", "head", "-n", "1"}, 3);
+        logger.debug("commander result: " + result);
         String spokePath = StringUtils.substring(result, 31);
         return ChannelContentKey.fromSpokePath(spokePath);
     }

--- a/src/main/java/com/flightstats/hub/spoke/SpokeContentDao.java
+++ b/src/main/java/com/flightstats/hub/spoke/SpokeContentDao.java
@@ -66,7 +66,8 @@ public class SpokeContentDao {
         String storePath = "/spoke/" + store.name().toLowerCase();
         logger.trace("getting oldest item from " + storePath);
         // expected result format: YYYY-MM-DD+HH:MM:SS.SSSSSSSSSS /spoke/store/channel/yyyy/mm/dd/hh/mm/ssSSShash
-        String result = Commander.run(new String[]{"/bin/bash", "-c", "find " + storePath + " -type f -printf '%T+ %p\\n' | sort | head -n 1"}, 3);
+        String[] command = new String[]{"/bin/bash", "-c", "find " + storePath + " -type f -printf '%T+ %p\\n' | sort | head -n 1"};
+        String result = Commander.run(command, 3);
         String spokePath = StringUtils.substring(result, 31);
         return ChannelContentKey.fromSpokePath(spokePath);
     }

--- a/src/main/java/com/flightstats/hub/spoke/SpokeContentDao.java
+++ b/src/main/java/com/flightstats/hub/spoke/SpokeContentDao.java
@@ -66,7 +66,7 @@ public class SpokeContentDao {
         String storePath = "/spoke/" + store.name().toLowerCase();
         logger.trace("getting oldest item from " + storePath);
         // expected result format: YYYY-MM-DD+HH:MM:SS.SSSSSSSSSS /spoke/store/channel/yyyy/mm/dd/hh/mm/ssSSShash
-        String result = Commander.run(new String[]{"/bin/bash", "-c", "find " + storePath + " -type f -printf '%T+ %p' | sort | head -n 1"}, 3);
+        String result = Commander.run(new String[]{"/bin/bash", "-c", "find " + storePath + " -type f -printf '%T+ %p\\n' | sort | head -n 1"}, 3);
         String spokePath = StringUtils.substring(result, 31);
         return ChannelContentKey.fromSpokePath(spokePath);
     }

--- a/src/main/java/com/flightstats/hub/spoke/SpokeContentDao.java
+++ b/src/main/java/com/flightstats/hub/spoke/SpokeContentDao.java
@@ -66,8 +66,7 @@ public class SpokeContentDao {
         String storePath = "/spoke/" + store.name().toLowerCase();
         logger.trace("getting oldest item from " + storePath);
         // expected result format: YYYY-MM-DD+HH:MM:SS.SSSSSSSSSS /spoke/store/channel/yyyy/mm/dd/hh/mm/ssSSShash
-        String result = Commander.run(new String[]{"find", storePath, "-type", "f", "-printf", "'%T+ %p\n'", "|", "sort", "|", "head", "-n", "1"}, 3);
-        logger.debug("commander result: " + result);
+        String result = Commander.run(new String[]{"find", storePath, "-type f", "-printf '%T+ %p\\n'", "|", "sort", "|", "head", "-n", "1"}, 3);
         String spokePath = StringUtils.substring(result, 31);
         return ChannelContentKey.fromSpokePath(spokePath);
     }

--- a/src/main/java/com/flightstats/hub/spoke/SpokeContentDao.java
+++ b/src/main/java/com/flightstats/hub/spoke/SpokeContentDao.java
@@ -78,6 +78,6 @@ public class SpokeContentDao {
         logger.trace("getting the total number of items in " + storePath);
         String[] command = new String[]{"/bin/bash", "-c", "find " + storePath + " -type f | wc -l"};
         String result = Commander.run(command, 1);
-        return Long.valueOf(result);
+        return Long.valueOf(StringUtils.chomp(result));
     }
 }

--- a/src/main/java/com/flightstats/hub/spoke/SpokeContentDao.java
+++ b/src/main/java/com/flightstats/hub/spoke/SpokeContentDao.java
@@ -66,7 +66,7 @@ public class SpokeContentDao {
         String storePath = "/spoke/" + store.name().toLowerCase();
         logger.trace("getting oldest item from " + storePath);
         // expected result format: YYYY-MM-DD+HH:MM:SS.SSSSSSSSSS /spoke/store/channel/yyyy/mm/dd/hh/mm/ssSSShash
-        String result = Commander.run(new String[]{"find", storePath, "-type f", "-printf '%T+ %p\\n'", "|", "sort", "|", "head", "-n", "1"}, 3);
+        String result = Commander.run(new String[]{"find", storePath, "-type f", "-printf '%T+ %p'", "|", "sort", "|", "head", "-n", "1"}, 3);
         String spokePath = StringUtils.substring(result, 31);
         return ChannelContentKey.fromSpokePath(spokePath);
     }

--- a/src/main/java/com/flightstats/hub/spoke/SpokeReadContentDao.java
+++ b/src/main/java/com/flightstats/hub/spoke/SpokeReadContentDao.java
@@ -126,4 +126,7 @@ public class SpokeReadContentDao implements ContentDao {
         throw new NotImplementedException("SpokeReadContentDao.deleteBefore not implemented");
     }
 
+    ChannelContentKey getOldestItem() {
+        return SpokeContentDao.getOldestItem(SpokeStore.READ);
+    }
 }

--- a/src/main/java/com/flightstats/hub/spoke/SpokeTtlEnforcer.java
+++ b/src/main/java/com/flightstats/hub/spoke/SpokeTtlEnforcer.java
@@ -12,6 +12,7 @@ import com.flightstats.hub.util.TimeUtil;
 import com.google.common.util.concurrent.AbstractScheduledService;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,6 +26,7 @@ public class SpokeTtlEnforcer {
     private final SpokeStore spokeStore;
     private final String storagePath;
     private final int ttlMinutes;
+    private long itemsEvicted = 0;
 
     @Inject
     private ChannelService channelService;
@@ -47,15 +49,27 @@ public class SpokeTtlEnforcer {
             if (channel.isLive()) {
                 DateTime ttlDateTime = TimeUtil.stable().minusMinutes(ttlMinutes + 1);
                 for (int i = 0; i < 2; i++) {
-                    Commander.run(new String[]{"rm", "-rf", channelPath + "/" + TimeUtil.minutes(ttlDateTime.minusMinutes(i))}, 1);
-                    Commander.run(new String[]{"rm", "-rf", channelPath + "/" + TimeUtil.hours(ttlDateTime.minusHours(i + 1))}, 5);
-                    Commander.run(new String[]{"rm", "-rf", channelPath + "/" + TimeUtil.days(ttlDateTime.minusDays(i + 1))}, 5);
-                    Commander.run(new String[]{"rm", "-rf", channelPath + "/" + TimeUtil.months(ttlDateTime.minusMonths(i + 1))}, 5);
+                    itemsEvicted += removeFromChannelByTime(channelPath, TimeUtil.minutes(ttlDateTime.minusMinutes(i)));
+                    itemsEvicted += removeFromChannelByTime(channelPath, TimeUtil.hours(ttlDateTime.minusHours(i + 1)));
+                    itemsEvicted += removeFromChannelByTime(channelPath, TimeUtil.days(ttlDateTime.minusDays(i + 1)));
+                    itemsEvicted += removeFromChannelByTime(channelPath, TimeUtil.months(ttlDateTime.minusMonths(i + 1)));
                 }
             } else {
-                Commander.run(new String[]{"find", channelPath, "-mmin", "+" + ttlMinutes, "-delete"}, 1);
+                itemsEvicted += removeFromChannelByAge(channelPath);
             }
         };
+    }
+
+    private long removeFromChannelByAge(String channelPath) {
+        String[] command = new String[]{"/bin/bash", "-c", "find", channelPath, "-mmin", "+" + ttlMinutes, "-exec rm -rfv {} + | grep \"removed '\" | wc -l"};
+        String result = Commander.run(command, 5);
+        return Long.valueOf(StringUtils.chomp(result));
+    }
+
+    private long removeFromChannelByTime(String channelPath, String timePath) {
+        String[] command = new String[]{"/bin/bash", "-c", "rm -rfv " + channelPath + "/" + timePath + " | grep \"removed '\" | wc -l"};
+        String result = Commander.run(command, 5);
+        return Long.valueOf(StringUtils.chomp(result));
     }
 
     private void updateOldestItemMetric() {
@@ -66,17 +80,20 @@ public class SpokeTtlEnforcer {
         }
     }
 
+    private void updateItemsEvictedMetric() {
+        metricsService.gauge("spoke." + spokeStore.name().toLowerCase() + ".evicted", itemsEvicted);
+        itemsEvicted = 0;
+    }
+
     private class SpokeTtlEnforcerService extends AbstractScheduledService {
         @Override
         protected void runOneIteration() throws Exception {
             try {
                 long start = System.currentTimeMillis();
                 logger.info("running ttl cleanup");
-                long itemsBefore = SpokeContentDao.getNumberOfItems(spokeStore);
                 TtlEnforcer.enforce(storagePath, channelService, handleCleanup());
-                long itemsAfter = SpokeContentDao.getNumberOfItems(spokeStore);
-                metricsService.gauge("spoke." + spokeStore.name().toLowerCase() + ".total", itemsAfter - itemsBefore);
                 updateOldestItemMetric();
+                updateItemsEvictedMetric();
                 logger.info("completed ttl cleanup {}", (System.currentTimeMillis() - start));
             } catch (Exception e) {
                 logger.info("issue cleaning up spoke", e);

--- a/src/main/java/com/flightstats/hub/spoke/SpokeTtlEnforcer.java
+++ b/src/main/java/com/flightstats/hub/spoke/SpokeTtlEnforcer.java
@@ -55,7 +55,6 @@ public class SpokeTtlEnforcer {
             } else {
                 Commander.run(new String[]{"find", channelPath, "-mmin", "+" + ttlMinutes, "-delete"}, 1);
             }
-            updateOldestItemMetric();
         };
     }
 
@@ -74,6 +73,7 @@ public class SpokeTtlEnforcer {
                 long start = System.currentTimeMillis();
                 logger.info("running ttl cleanup");
                 TtlEnforcer.enforce(storagePath, channelService, handleCleanup());
+                updateOldestItemMetric();
                 logger.info("completed ttl cleanup {}", (System.currentTimeMillis() - start));
             } catch (Exception e) {
                 logger.info("issue cleaning up spoke", e);

--- a/src/main/java/com/flightstats/hub/spoke/SpokeTtlEnforcer.java
+++ b/src/main/java/com/flightstats/hub/spoke/SpokeTtlEnforcer.java
@@ -63,7 +63,7 @@ public class SpokeTtlEnforcer {
         ChannelContentKey oldestItem = SpokeContentDao.getOldestItem(spokeStore);
         Long oldestItemAgeMS = oldestItem.getAgeMS();
         if (oldestItemAgeMS != null) {
-            metricsService.gauge("spoke." + spokeStore.name() + ".age.oldest", oldestItemAgeMS);
+            metricsService.gauge("spoke." + spokeStore.name().toLowerCase() + ".age.oldest", oldestItemAgeMS);
         }
     }
 

--- a/src/main/java/com/flightstats/hub/spoke/SpokeTtlEnforcer.java
+++ b/src/main/java/com/flightstats/hub/spoke/SpokeTtlEnforcer.java
@@ -60,7 +60,9 @@ public class SpokeTtlEnforcer {
     }
 
     private void updateOldestItemMetric() {
+        logger.trace("updating oldest item metric");
         ChannelContentKey oldestItem = SpokeContentDao.getOldestItem(spokeStore);
+        logger.debug("oldest item: " + oldestItem.toString());
         Long oldestItemAgeMS = oldestItem.getAgeMS();
         if (oldestItemAgeMS != null) {
             metricsService.gauge("spoke." + spokeStore.name() + ".age.oldest", oldestItemAgeMS);

--- a/src/main/java/com/flightstats/hub/spoke/SpokeTtlEnforcer.java
+++ b/src/main/java/com/flightstats/hub/spoke/SpokeTtlEnforcer.java
@@ -72,7 +72,10 @@ public class SpokeTtlEnforcer {
             try {
                 long start = System.currentTimeMillis();
                 logger.info("running ttl cleanup");
+                long itemsBefore = SpokeContentDao.getNumberOfItems(spokeStore);
                 TtlEnforcer.enforce(storagePath, channelService, handleCleanup());
+                long itemsAfter = SpokeContentDao.getNumberOfItems(spokeStore);
+                metricsService.gauge("spoke." + spokeStore.name().toLowerCase() + ".total", itemsAfter - itemsBefore);
                 updateOldestItemMetric();
                 logger.info("completed ttl cleanup {}", (System.currentTimeMillis() - start));
             } catch (Exception e) {

--- a/src/main/java/com/flightstats/hub/spoke/SpokeTtlEnforcer.java
+++ b/src/main/java/com/flightstats/hub/spoke/SpokeTtlEnforcer.java
@@ -60,9 +60,7 @@ public class SpokeTtlEnforcer {
     }
 
     private void updateOldestItemMetric() {
-        logger.trace("updating oldest item metric");
         ChannelContentKey oldestItem = SpokeContentDao.getOldestItem(spokeStore);
-        logger.debug("oldest item: " + oldestItem.toString());
         Long oldestItemAgeMS = oldestItem.getAgeMS();
         if (oldestItemAgeMS != null) {
             metricsService.gauge("spoke." + spokeStore.name() + ".age.oldest", oldestItemAgeMS);

--- a/src/main/java/com/flightstats/hub/spoke/SpokeWriteContentDao.java
+++ b/src/main/java/com/flightstats/hub/spoke/SpokeWriteContentDao.java
@@ -189,4 +189,8 @@ public class SpokeWriteContentDao implements ContentDao {
     public void initialize() {
         //do anything?
     }
+
+    ChannelContentKey getOldestItem() {
+        return SpokeContentDao.getOldestItem(SpokeStore.WRITE);
+    }
 }

--- a/src/test/java/com/flightstats/hub/model/ChannelContentKeyTest.java
+++ b/src/test/java/com/flightstats/hub/model/ChannelContentKeyTest.java
@@ -44,7 +44,7 @@ public class ChannelContentKeyTest {
 
     @Test
     public void fromSpokePath() {
-        String filePath = "/spoke/write/foo/1999/12/31/23/59/59999l33t";
+        String filePath = "/mnt/spoke/write/foo/1999/12/31/23/59/59999l33t";
         ChannelContentKey key = ChannelContentKey.fromSpokePath(filePath);
         assertEquals(key.getChannel(), "foo");
         assertEquals(key.getContentKey(), new ContentKey(1999, 12, 31, 23, 59, 59, 999, "l33t"));

--- a/src/test/java/com/flightstats/hub/model/ChannelContentKeyTest.java
+++ b/src/test/java/com/flightstats/hub/model/ChannelContentKeyTest.java
@@ -33,4 +33,28 @@ public class ChannelContentKeyTest {
         ChannelContentKey cycled = channelContentKey.fromUrl(channelContentKey.toUrl());
         assertEquals(channelContentKey, cycled);
     }
+
+    @Test
+    public void fromUrl() {
+        String url = "http://hub/channel/foo/1999/12/31/23/59/59/999/l33t";
+        ChannelContentKey key = ChannelContentKey.fromUrl(url);
+        assertEquals(key.getChannel(), "foo");
+        assertEquals(key.getContentKey(), new ContentKey(1999, 12, 31, 23, 59, 59, 999, "l33t"));
+    }
+
+    @Test
+    public void fromSpokePath() {
+        String filePath = "/spoke/write/foo/1999/12/31/23/59/59999l33t";
+        ChannelContentKey key = ChannelContentKey.fromSpokePath(filePath);
+        assertEquals(key.getChannel(), "foo");
+        assertEquals(key.getContentKey(), new ContentKey(1999, 12, 31, 23, 59, 59, 999, "l33t"));
+    }
+
+    @Test
+    public void fromChannelPath() {
+        String path = "foo/1999/12/31/23/59/59/999/l33t";
+        ChannelContentKey key = ChannelContentKey.fromChannelPath(path);
+        assertEquals(key.getChannel(), "foo");
+        assertEquals(key.getContentKey(), new ContentKey(1999, 12, 31, 23, 59, 59, 999, "l33t"));
+    }
 }


### PR DESCRIPTION
When the `SpokeTtlEnforcer` runs, once a minute, it gets the oldest item from Spoke and emits it's age in milliseconds under the following names; `hub.spoke.write.age.oldest` and `hub.spoke.read.age.oldest` (depending on which enforcer is running).