### PR TITLE
Fix is cluster

### DIFF
--- a/src/test/javascript/integration/webhook_leaky_callback_demo_spec.js
+++ b/src/test/javascript/integration/webhook_leaky_callback_demo_spec.js
@@ -6,9 +6,9 @@ const {
     getProp,
     getWebhookUrl,
     hubClientDelete,
-    hubClientGet,
     hubClientPut,
     hubClientPostTestItem,
+    isClusteredHubNode,
     randomChannelName,
     startServer,
     waitForCondition,
@@ -17,7 +17,6 @@ const {
     getCallBackDomain,
     getCallBackPort,
     getChannelUrl,
-    getHubUrlBase,
 } = require('../lib/config');
 
 const headers = { 'Content-Type': 'application/json' };
@@ -47,13 +46,7 @@ describe('callback leak on same callbackServer, port, path', () => {
         if (getProp('statusCode', channel) === 201) {
             console.log(`created channel for ${__filename}`);
         }
-
-        const headers = { 'Content-Type': 'application/json' };
-        const url = `${getHubUrlBase()}/internal/properties`;
-        const response1 = await hubClientGet(url, headers);
-        const properties = fromObjectPath(['body', 'properties'], response1) || {};
-        const hubType = properties['hub.type'];
-        context[channelUrl].isClustered = hubType === 'aws';
+        context[channelUrl].isClustered = await isClusteredHubNode();
         console.log('isClustered:', context[channelUrl].isClustered);
     });
 

--- a/src/test/javascript/integration/webhook_localhost_spec.js
+++ b/src/test/javascript/integration/webhook_localhost_spec.js
@@ -2,15 +2,13 @@ const {
     deleteWebhook,
     getProp,
     getWebhookUrl,
-    fromObjectPath,
     hubClientDelete,
-    hubClientGet,
     hubClientPut,
+    isClusteredHubNode,
     randomChannelName,
 } = require('../lib/helpers');
 const {
     getChannelUrl,
-    getHubUrlBase,
 } = require('../lib/config');
 
 const channelUrl = getChannelUrl();
@@ -31,14 +29,7 @@ describe(__filename, function () {
     let isClustered = true;
     const headers = { 'Content-Type': 'application/json' };
     it('determines if this is a single or clustered hub', async () => {
-        const url = `${getHubUrlBase()}/internal/properties`;
-        const response = await hubClientGet(url, headers);
-        expect(getProp('statusCode', response)).toEqual(200);
-        const properties = fromObjectPath(['body', 'properties'], response) || {};
-        const hubType = properties['hub.type'];
-        if (hubType !== undefined) {
-            isClustered = hubType === 'aws';
-        }
+        isClustered = await isClusteredHubNode();
         console.log('isClustered:', isClustered);
     });
 

--- a/src/test/javascript/integration/webhook_tag_prototype_spec.js
+++ b/src/test/javascript/integration/webhook_tag_prototype_spec.js
@@ -1,10 +1,10 @@
 const {
-    fromObjectPath,
     getProp,
     getWebhookUrl,
     hubClientDelete,
     hubClientGet,
     hubClientPut,
+    isClusteredHubNode,
     itSleeps,
     randomChannelName,
     randomTag,
@@ -33,12 +33,7 @@ const acceptJSON = { "Content-Type": "application/json" };
 
 describe(__filename, function () {
     beforeAll(async () => {
-        const headers = { 'Content-Type': 'application/json' };
-        const url = `${getHubUrlBase()}/internal/properties`;
-        const response = await hubClientGet(url, headers);
-        const properties = fromObjectPath(['body', 'properties'], response) || {};
-        const hubType = properties['hub.type'];
-        context[tag].isClustered = hubType === 'aws';
+        context[tag].isClustered = await isClusteredHubNode();
         console.log('isClustered:', context[tag].isClustered);
     });
 

--- a/src/test/javascript/lib/helpers/hub-client.js
+++ b/src/test/javascript/lib/helpers/hub-client.js
@@ -247,9 +247,9 @@ const hubClientGetUntil = async (url, clause, timeoutMS = 30000, interval = 1000
     }
 };
 
-const getPort = (path) => {
+const getHostname = (path) => {
     const url = new URL(path);
-    return url.port;
+    return url.hostname;
 };
 
 const isClusteredHubNode = async () => {
@@ -261,7 +261,7 @@ const isClusteredHubNode = async () => {
     const servers = fromObjectPath(['body', 'servers'], response) || [];
     const server = fromObjectPath(['body', 'server'], response) || '';
     const indeterminate = !server || !servers.length;
-    const single = servers.length === 1 && getPort(servers[0]) === getPort(server);
+    const single = servers.length === 1 && getHostname(servers[0]) === getHostname(server);
     return !indeterminate && !single;
 };
 

--- a/src/test/javascript/lib/helpers/hub-client.js
+++ b/src/test/javascript/lib/helpers/hub-client.js
@@ -253,7 +253,7 @@ const getHostname = (path) => {
 };
 
 const isClusteredHubNode = async () => {
-    const headers = { 'Accept': 'application/json' };
+    const headers = { 'Content-Type': 'application/json' };
     const url = `${getHubUrlBase()}/internal/properties`;
     const response = await hubClientGet(url, headers);
     const properties = fromObjectPath(['body', 'properties'], response) || {};

--- a/src/test/javascript/lib/helpers/hub-client.js
+++ b/src/test/javascript/lib/helpers/hub-client.js
@@ -1,3 +1,4 @@
+const { URL } = require('url');
 const rp = require('request-promise-native');
 const moment = require('moment');
 const { fromObjectPath, getProp, itSleeps } = require('./functional');
@@ -246,6 +247,24 @@ const hubClientGetUntil = async (url, clause, timeoutMS = 30000, interval = 1000
     }
 };
 
+const getPort = (path) => {
+    const url = new URL(path);
+    return url.port;
+};
+
+const isClusteredHubNode = async () => {
+    const headers = { 'Accept': 'application/json' };
+    const url = `${getHubUrlBase()}/internal/properties`;
+    const response = await hubClientGet(url, headers);
+    const properties = fromObjectPath(['body', 'properties'], response) || {};
+    if (properties['hub.type'] === 'aws') return true;
+    const servers = fromObjectPath(['body', 'servers'], response) || [];
+    const server = fromObjectPath(['body', 'server'], response) || '';
+    const indeterminate = !server || !servers.length;
+    const single = servers.length === 1 && getPort(servers[0]) === getPort(server);
+    return !indeterminate && !single;
+};
+
 module.exports = {
     createChannel,
     followRedirectIfPresent,
@@ -258,4 +277,5 @@ module.exports = {
     hubClientPost,
     hubClientPostTestItem,
     hubClientPut,
+    isClusteredHubNode,
 };

--- a/src/test/javascript/lib/helpers/index.js
+++ b/src/test/javascript/lib/helpers/index.js
@@ -28,6 +28,7 @@ const {
     hubClientPost,
     hubClientPostTestItem,
     hubClientPut,
+    isClusteredHubNode,
 } = require('./hub-client');
 const {
     deleteWebhook,
@@ -57,6 +58,7 @@ module.exports = {
     hubClientPost,
     hubClientPostTestItem,
     hubClientPut,
+    isClusteredHubNode,
     itSleeps,
     parseJson,
     processChunks,


### PR DESCRIPTION
Tests were failing in CI due to "hub.type"="aws" not being set in hub.properties.
That seems a little non-deterministic as "hub.type"="aws" is default true even if hub.properties
and thereby hub-url/internal/properties return it or not.
I added a helper function and made this more deterministic to avoid occasional false negatives