### PR TITLE
Regularly delete inactive webhook leaders in ZK

### DIFF
--- a/src/main/java/com/flightstats/hub/util/SafeZooKeeperUtils.java
+++ b/src/main/java/com/flightstats/hub/util/SafeZooKeeperUtils.java
@@ -1,0 +1,138 @@
+package com.flightstats.hub.util;
+
+import com.flightstats.hub.cluster.CuratorLock;
+import com.flightstats.hub.cluster.ZooKeeperState;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import lombok.Builder;
+import lombok.Getter;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.api.Backgroundable;
+import org.apache.curator.framework.api.ChildrenDeletable;
+import org.apache.curator.framework.api.DeleteBuilder;
+import org.apache.curator.framework.api.GetDataBuilder;
+import org.apache.curator.framework.api.Pathable;
+import org.apache.curator.framework.recipes.cache.PathChildrenCache;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Collections.emptyList;
+
+@Singleton
+// NOTE: The purpose of this ZooKeeper wrapper is to encapsulate and standardize the logging + error-swallowing that's
+// a common hub pattern.
+public class SafeZooKeeperUtils {
+    private static final Logger logger = LoggerFactory.getLogger(SafeZooKeeperUtils.class);
+    private final CuratorFramework curator;
+
+    @Inject
+    public SafeZooKeeperUtils(CuratorFramework curator) {
+        this.curator = curator;
+    }
+
+    public PathChildrenCache initializeCache(String... pathParts) throws Exception {
+        PathChildrenCache cache = new PathChildrenCache(curator, getPath(newArrayList(pathParts)), true);
+        cache.start(PathChildrenCache.StartMode.BUILD_INITIAL_CACHE);
+        return cache;
+    }
+
+    public List<String> getChildren(String... parentPathParts) {
+        return doItSafely(path -> curator.getChildren().forPath(path),
+                newArrayList(parentPathParts),
+                "unable to get children",
+                emptyList());
+    }
+
+    public Optional<String> getData(String... pathParts) {
+        return getData(builder -> builder, pathParts);
+    }
+
+    public Optional<DataWithStat> getDataWithStat(String... pathParts) {
+        Stat stat = new Stat();
+        return getData(builder -> builder.storingStatIn(stat), pathParts)
+                .map(data -> DataWithStat.builder().data(data).stat(stat).build());
+    }
+
+    public void createPathAndParents(String... pathParts) {
+        doItSafely(path -> curator.create().creatingParentsIfNeeded().forPath(path),
+                newArrayList(pathParts),
+                "unable to create",
+                null);
+    }
+
+    public void createData(byte[] data, String... pathParts) {
+        doItSafely(path -> curator.create().creatingParentsIfNeeded().forPath(path, data),
+                newArrayList(pathParts),
+                "unable to create with data",
+                null
+        );
+    }
+
+    public void delete(String... pathParts) {
+        deletePath(builder -> builder, pathParts);
+    }
+
+    public void deletePathAndChildren(String... pathParts) {
+        deletePath(ChildrenDeletable::deletingChildrenIfNeeded, pathParts);
+    }
+
+    public void deletePathInBackground(String... pathParts) {
+        deletePath(Backgroundable::inBackground, pathParts);
+    }
+
+    @Builder
+    @Getter
+    public static class DataWithStat {
+        Stat stat;
+        String data;
+    }
+
+    private Optional<String> getData(Function<GetDataBuilder, Pathable<byte[]>> dataBuilder, String... pathParts) {
+        return doItSafely(path -> {
+                    GetDataBuilder data = curator.getData();
+                    byte[] bytes = dataBuilder.apply(data).forPath(path);
+                    return Optional.of(new String(bytes));
+                },
+                newArrayList(pathParts),
+                "unable to get data",
+                Optional.empty());
+    }
+
+
+    private void deletePath(Function<DeleteBuilder, Pathable<Void>> deleteBuilder, String... pathParts) {
+        doItSafely(path -> deleteBuilder.apply(curator.delete()).forPath(path),
+                newArrayList(pathParts),
+                "unable to delete",
+                null);
+    }
+
+    @FunctionalInterface
+    private interface CheckedCuratorAction<String, R> {
+        R apply(String t) throws Exception;
+    }
+
+    private <T> T doItSafely(CheckedCuratorAction<String, T> curatorAction, List<String> pathParts, String failureMessage, T defaultValue) {
+        String path = getPath(pathParts);
+        try {
+            return curatorAction.apply(path);
+        } catch (KeeperException.NodeExistsException ignore) {
+            logger.info("node exists " + path);
+        } catch (KeeperException.NoNodeException ignore) {
+            logger.info("no node exists " + path);
+        } catch (Exception e) {
+            logger.warn(failureMessage + " " + path, e);
+        }
+        return defaultValue;
+    }
+
+    private String getPath(List<String> pathParts) {
+        return String.join("/", pathParts);
+    }
+}

--- a/src/main/java/com/flightstats/hub/webhook/ActiveWebhookSweeper.java
+++ b/src/main/java/com/flightstats/hub/webhook/ActiveWebhookSweeper.java
@@ -1,0 +1,42 @@
+package com.flightstats.hub.webhook;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+public class ActiveWebhookSweeper {
+    private static final Logger logger = LoggerFactory.getLogger(ActiveWebhookSweeper.class);
+    private final WebhookLeaderLocks webhookLeaderLocks;
+
+    @Inject
+    public ActiveWebhookSweeper(WebhookLeaderLocks webhookLeaderLocks) {
+        this.webhookLeaderLocks = webhookLeaderLocks;
+    }
+
+    void cleanupEmpty() {
+        logger.info("cleaning empty webhook leader nodes...");
+
+        Set<String> currentData = webhookLeaderLocks.getWebhooks();
+        logger.info("data {}", currentData.size());
+
+        currentData.stream()
+                .filter(this::isEmpty)
+                .forEach(this::deleteWebhookLeader);
+    }
+
+    private boolean isEmpty(String webhookName) {
+        return Stream.of(webhookLeaderLocks.getLeasePaths(webhookName), webhookLeaderLocks.getLockPaths(webhookName))
+                .allMatch(List::isEmpty);
+    }
+
+    private void deleteWebhookLeader(String webhookName) {
+        logger.info("deleting empty {}", webhookName);
+        webhookLeaderLocks.deleteWebhookLeader(webhookName);
+
+    }
+
+}

--- a/src/main/java/com/flightstats/hub/webhook/ActiveWebhooks.java
+++ b/src/main/java/com/flightstats/hub/webhook/ActiveWebhooks.java
@@ -1,91 +1,31 @@
 package com.flightstats.hub.webhook;
 
 import com.flightstats.hub.app.HubHost;
-import com.flightstats.hub.util.SafeZooKeeperUtils;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.curator.framework.recipes.cache.PathChildrenCache;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.util.List;
 import java.util.Set;
-import java.util.stream.Stream;
 
-import static java.lang.String.format;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
 @Singleton
 public class ActiveWebhooks {
-    private static final Logger logger = LoggerFactory.getLogger(ActiveWebhooks.class);
-    private static final String WEBHOOK_LEADER = "/WebhookLeader";
-    private static final String LEASE_NODE = "leases";
-    private static final String LOCK_NODE = "locks";
-
-    private final SafeZooKeeperUtils zooKeeperUtils;
-
-    private PathChildrenCache webhooks;
+    private final WebhookLeaderLocks webhookLeaderLocks;
 
     @Inject
-    public ActiveWebhooks(SafeZooKeeperUtils safeZooKeeperUtils) throws Exception {
-        this.zooKeeperUtils = safeZooKeeperUtils;
+    public ActiveWebhooks(WebhookLeaderLocks webhookLeaderLocks, ActiveWebhookSweeper activeWebhookSweeper) {
+        this.webhookLeaderLocks = webhookLeaderLocks;
 
-        this.webhooks = zooKeeperUtils.initializeCache(WEBHOOK_LEADER);
-
-        logger.info("cleaning...");
-        cleanupEmpty();
+        activeWebhookSweeper.cleanupEmpty();
     }
 
-    @VisibleForTesting
-    void cleanupEmpty() {
-        logger.info("cleaning empty webhook leader nodes...");
-
-        Set<String> currentData = getWebhooks();
-        logger.info("data {}", currentData.size());
-
-        List<String> emptyWebhookLeaders = currentData.stream()
-                .filter(this::isEmpty)
-                .collect(toList());
-
-        emptyWebhookLeaders.forEach(this::deleteWebhookLeader);
+    public boolean isActiveWebhook(String webhookName) {
+        return webhookLeaderLocks.getWebhooks().contains(webhookName);
     }
 
-    private Set<String> getWebhooks() {
-        return webhooks.getCurrentData().stream()
-                .map((childData -> StringUtils.substringAfterLast(childData.getPath(), "/")))
+    public Set<String> getServers(String name) {
+        return webhookLeaderLocks.getServerLeases(name).stream()
+                .map(server -> server + ":" + HubHost.getLocalPort())
                 .collect(toSet());
-    }
-
-    boolean isActiveWebhook(String webhookName) {
-        return getWebhooks().contains(webhookName);
-    }
-
-    public Set<String> getServers(String webhookName) {
-        return zooKeeperUtils.getChildren(WEBHOOK_LEADER, webhookName, LEASE_NODE).stream()
-                .map(lease -> zooKeeperUtils.getData(WEBHOOK_LEADER, webhookName, LEASE_NODE, lease))
-                .flatMap(optional -> optional.map(Stream::of).orElse(Stream.empty()))
-                .map(server -> format("%s:%s", server, HubHost.getLocalPort()))
-                .collect(toSet());
-    }
-
-    private boolean isEmpty(String webhookName) {
-        return Stream.of(getLeasePaths(webhookName), getLockPaths(webhookName))
-                .allMatch(List::isEmpty);
-    }
-
-    private List<String> getLeasePaths(String webhookName) {
-        return zooKeeperUtils.getChildren(WEBHOOK_LEADER, webhookName, LEASE_NODE);
-    }
-
-    private List<String> getLockPaths(String webhookName) {
-        return zooKeeperUtils.getChildren(WEBHOOK_LEADER, webhookName, LOCK_NODE);
-    }
-
-    private void deleteWebhookLeader(String webhookName) {
-        logger.info("deleting empty {}", webhookName);
-        zooKeeperUtils.deletePathAndChildren(WEBHOOK_LEADER, webhookName);
     }
 }

--- a/src/main/java/com/flightstats/hub/webhook/ActiveWebhooks.java
+++ b/src/main/java/com/flightstats/hub/webhook/ActiveWebhooks.java
@@ -1,22 +1,27 @@
 package com.flightstats.hub.webhook;
 
 import com.flightstats.hub.app.HubHost;
+import com.google.common.util.concurrent.AbstractScheduledService;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
+import static com.flightstats.hub.app.HubServices.register;
 import static java.util.stream.Collectors.toSet;
 
 @Singleton
 public class ActiveWebhooks {
     private final WebhookLeaderLocks webhookLeaderLocks;
+    private final ActiveWebhookSweeper activeWebhookSweeper;
 
     @Inject
     public ActiveWebhooks(WebhookLeaderLocks webhookLeaderLocks, ActiveWebhookSweeper activeWebhookSweeper) {
         this.webhookLeaderLocks = webhookLeaderLocks;
+        this.activeWebhookSweeper = activeWebhookSweeper;
 
-        activeWebhookSweeper.cleanupEmpty();
+        register(new WebhookLeaderCleanupService());
     }
 
     public boolean isActiveWebhook(String webhookName) {
@@ -27,5 +32,17 @@ public class ActiveWebhooks {
         return webhookLeaderLocks.getServerLeases(name).stream()
                 .map(server -> server + ":" + HubHost.getLocalPort())
                 .collect(toSet());
+    }
+
+    private class WebhookLeaderCleanupService extends AbstractScheduledService {
+        @Override
+        protected void runOneIteration() throws Exception {
+            activeWebhookSweeper.cleanupEmpty();
+        }
+
+        @Override
+        protected Scheduler scheduler() {
+            return Scheduler.newFixedRateSchedule(2, 5, TimeUnit.MINUTES);
+        }
     }
 }

--- a/src/main/java/com/flightstats/hub/webhook/WebhookContentPathSet.java
+++ b/src/main/java/com/flightstats/hub/webhook/WebhookContentPathSet.java
@@ -1,76 +1,39 @@
 package com.flightstats.hub.webhook;
 
 import com.flightstats.hub.model.ContentPath;
+import com.flightstats.hub.util.SafeZooKeeperUtils;
 import com.google.inject.Inject;
-import org.apache.curator.framework.CuratorFramework;
-import org.apache.zookeeper.KeeperException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
-class WebhookContentPathSet {
-    private final static Logger logger = LoggerFactory.getLogger(WebhookContentPathSet.class);
+import static java.util.stream.Collectors.toSet;
 
-    private final CuratorFramework curator;
+class WebhookContentPathSet {
+    private final static String BASE_PATH = "/GroupInFlight";
+
+    private final SafeZooKeeperUtils zooKeeperUtils;
 
     @Inject
-    public WebhookContentPathSet(CuratorFramework curator) {
-        this.curator = curator;
+    public WebhookContentPathSet(SafeZooKeeperUtils zooKeeperUtils) {
+        this.zooKeeperUtils = zooKeeperUtils;
     }
 
     public void add(String webhookName, ContentPath key) {
-        String path = getPath(webhookName, key);
-        try {
-            curator.create().creatingParentsIfNeeded().forPath(path);
-        } catch (KeeperException.NodeExistsException ignore) {
-            logger.info("node exists " + path);
-        } catch (Exception e) {
-            logger.warn("unable to create " + path, e);
-        }
+        zooKeeperUtils.createPathAndParents(BASE_PATH, webhookName, key.toZk());
     }
 
     public void remove(String webhookName, ContentPath key) {
-        String path = getPath(webhookName, key);
-        try {
-            curator.delete().forPath(path);
-        } catch (Exception e) {
-            logger.warn("unable to delete " + path, e);
-        }
+        zooKeeperUtils.delete(BASE_PATH, webhookName, key.toZk());
     }
 
-    Set<ContentPath> getSet(String webhookName, ContentPath type) {
-        String path = getPath(webhookName);
-        Set<ContentPath> keys = new HashSet<>();
-        try {
-            List<String> strings = curator.getChildren().forPath(path);
-            for (String string : strings) {
-                keys.add(type.fromZk(string));
-            }
-        } catch (KeeperException.NoNodeException e) {
-            logger.info("no node for {}", path);
-        } catch (Exception e) {
-            logger.warn("unable to get set " + path, e);
-        }
-        return keys;
-    }
-
-    private String getPath(String webhookName) {
-        return "/GroupInFlight/" + webhookName;
-    }
-
-    private String getPath(String webhookName, ContentPath key) {
-        return getPath(webhookName) + "/" + key.toZk();
+    public Set<ContentPath> getSet(String webhookName, ContentPath type) {
+        return zooKeeperUtils.getChildren(BASE_PATH, webhookName)
+                .stream()
+                .map(type::fromZk)
+                .collect(toSet());
     }
 
     public void delete(String webhookName) {
-        String path = getPath(webhookName);
-        try {
-            curator.delete().deletingChildrenIfNeeded().forPath(path);
-        } catch (Exception e) {
-            logger.warn("unable to delete {} {}", path, e.getMessage());
-        }
+        zooKeeperUtils.deletePathAndChildren(BASE_PATH, webhookName);
     }
 }

--- a/src/main/java/com/flightstats/hub/webhook/WebhookLeaderLocks.java
+++ b/src/main/java/com/flightstats/hub/webhook/WebhookLeaderLocks.java
@@ -1,0 +1,60 @@
+package com.flightstats.hub.webhook;
+
+import com.flightstats.hub.util.SafeZooKeeperUtils;
+import com.google.inject.Singleton;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.curator.framework.recipes.cache.ChildData;
+import org.apache.curator.framework.recipes.cache.PathChildrenCache;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toSet;
+
+@Singleton
+public class WebhookLeaderLocks {
+    private static final String WEBHOOK_LEADER = "/WebhookLeader";
+    private static final String LEASE_NODE = "leases";
+    private static final String LOCK_NODE = "locks";
+    private final SafeZooKeeperUtils zooKeeperUtils;
+
+    private PathChildrenCache webhooks;
+
+    @Inject
+    public WebhookLeaderLocks(SafeZooKeeperUtils zooKeeperUtils) throws Exception {
+        this.zooKeeperUtils = zooKeeperUtils;
+
+        webhooks = zooKeeperUtils.initializeCache(WEBHOOK_LEADER);
+    }
+
+    Set<String> getServerLeases(String webhook) {
+        return getLeasePaths(webhook).stream()
+                .map(lease -> zooKeeperUtils.getData(WEBHOOK_LEADER, webhook, LEASE_NODE, lease))
+                .flatMap(optional -> optional.map(Stream::of).orElse(Stream.empty()))
+                .collect(toSet());
+    }
+
+    Set<String> getWebhooks() {
+        return getWebhookCache().stream()
+                .map((childData -> StringUtils.substringAfterLast(childData.getPath(), "/")))
+                .collect(toSet());
+    }
+
+    List<String> getLeasePaths(String webhookName) {
+        return zooKeeperUtils.getChildren(WEBHOOK_LEADER, webhookName, LEASE_NODE);
+    }
+
+    List<String> getLockPaths(String webhookName) {
+        return zooKeeperUtils.getChildren(WEBHOOK_LEADER, webhookName, LOCK_NODE);
+    }
+
+    void deleteWebhookLeader(String webhookName) {
+        zooKeeperUtils.deletePathAndChildren(WEBHOOK_LEADER, webhookName);
+    }
+
+    private List<ChildData> getWebhookCache() {
+        return webhooks.getCurrentData();
+    }
+}

--- a/src/test/java/com/flightstats/hub/util/SafeZooKeeperUtilsTest.java
+++ b/src/test/java/com/flightstats/hub/util/SafeZooKeeperUtilsTest.java
@@ -1,0 +1,188 @@
+package com.flightstats.hub.util;
+
+import com.flightstats.hub.cluster.ZooKeeperState;
+import com.flightstats.hub.test.Integration;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.zookeeper.KeeperException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Collections.emptyList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class SafeZooKeeperUtilsTest {
+    private static CuratorFramework curator;
+    private static SafeZooKeeperUtils zooKeeperUtils;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        curator = Integration.startZooKeeper();
+        zooKeeperUtils = new SafeZooKeeperUtils(curator);
+    }
+
+    @Before
+    public void setupNode() throws Exception {
+        createNode("/some");
+    }
+
+    @After
+    public void cleanupNode() throws Exception {
+        curator.delete().deletingChildrenIfNeeded().forPath("/some");
+    }
+
+    @Test
+    public void testGetChildren_success() throws Exception {
+        createNode("/some/path");
+        createNode("/some/path/or");
+        createNode("/some/path/or/another");
+        createNode("/some/path/and/anotherer");
+
+        List<String> children = zooKeeperUtils.getChildren("/some", "path");
+
+        assertEquals(newArrayList("or", "and"), children);
+    }
+
+    @Test
+    public void testGetChildren_unknownNode() throws Exception {
+        List<String> children = zooKeeperUtils.getChildren("/some", "path");
+
+        assertEquals(emptyList(), children);
+    }
+
+    @Test
+    public void testGetData_success() throws Exception {
+        createNodeWithData("/some/path", "hey");
+        createNodeWithData("/some/path/or", "hi");
+
+        String data = zooKeeperUtils.getData("/some", "path", "or")
+                .orElseThrow(AssertionError::new);
+
+        assertEquals("hi", data);
+    }
+
+    @Test
+    public void testGetData_noData() throws Exception {
+        createNode("/some/path");
+        createNodeWithData("/some/path/or", "hi");
+
+        Optional<String> data = zooKeeperUtils.getData("/some", "path");
+
+        assertTrue(data.isPresent());
+    }
+
+    @Test
+    public void testGetData_unknownNode() throws Exception {
+        createNode("/some/path");
+
+        Optional<String> data = zooKeeperUtils.getData("/some", "path", "or");
+
+        assertFalse(data.isPresent());
+    }
+
+    @Test
+    public void testGetDataWithStat_success() throws Exception {
+        long startTime = TimeUtil.now().getMillis();
+        createNodeWithData("/some/path", "hey");
+        createNodeWithData("/some/path/or", "hi");
+
+        Optional<SafeZooKeeperUtils.DataWithStat> data = zooKeeperUtils.getDataWithStat("/some", "path", "or");
+
+        assertTrue(data.isPresent());
+        assertEquals("hi", data.get().getData());
+        assertTrue(data.get().getStat().getCtime() > startTime);
+    }
+
+    @Test
+    public void testGetDataWithStat_unknownNode() {
+        Optional<SafeZooKeeperUtils.DataWithStat> data = zooKeeperUtils.getDataWithStat("/some", "path", "or");
+
+        assertFalse(data.isPresent());
+    }
+
+    @Test
+    public void testCreatePathAndParents_success() throws Exception {
+        zooKeeperUtils.createPathAndParents("/some", "path", "or", "another");
+
+        assertEquals(newArrayList("another"), curator.getChildren().forPath("/some/path/or"));
+    }
+
+    @Test
+    public void testCreatePathAndParents_NodeExists() throws Exception {
+        createNode("/some/path/or/another/foo");
+
+        zooKeeperUtils.createPathAndParents("/some", "path", "or", "another");
+
+        assertEquals(newArrayList("foo"), curator.getChildren().forPath("/some/path/or/another"));
+    }
+
+    @Test
+    public void testCreateData_success() throws Exception {
+        zooKeeperUtils.createData("hi".getBytes(), "/some", "path");
+
+        assertEquals("hi", new String(curator.getData().forPath("/some/path")));
+    }
+
+    @Test
+    public void testCreateData_NodeExists() throws Exception {
+        createNodeWithData("/some/path", "hey");
+
+        zooKeeperUtils.createData("hi".getBytes(), "/some", "path");
+
+        assertEquals("hey", new String(curator.getData().forPath("/some/path")));
+    }
+
+    @Test
+    public void testDeletePathAndChildren_success() throws Exception {
+        createNode("/some/path/or/another/foo");
+
+        zooKeeperUtils.deletePathAndChildren("/some", "path", "or");
+
+        assertThrows(KeeperException.NoNodeException.class, () -> curator.getData().forPath("/some/path/or"));
+        assertEquals(newArrayList("path"), curator.getChildren().forPath("/some"));
+    }
+
+    @Test
+    public void testDeletePathAndChildren_unknownNode() throws Exception {
+        createNode("/some/path");
+        zooKeeperUtils.deletePathAndChildren("/some", "path", "or", "another");
+
+        assertThrows(KeeperException.NoNodeException.class, () -> curator.getData().forPath("/some/path/or/another"));
+        assertEquals(newArrayList("path"), curator.getChildren().forPath("/some"));
+    }
+
+    @Test
+    public void testDeletePathInBackground_success() throws Exception {
+        createNode("/some/path/or/another");
+        zooKeeperUtils.deletePathInBackground("/some", "path", "or", "another");
+
+        assertThrows(KeeperException.NoNodeException.class, () -> curator.getData().forPath("/some/path/or/another"));
+        assertEquals(newArrayList("or"), curator.getChildren().forPath("/some/path"));
+
+    }
+
+    @Test
+    public void testDeletePathInBackground_unknownNode() throws Exception {
+        createNode("/some/path/or");
+        zooKeeperUtils.deletePathAndChildren("/some", "path", "or", "another");
+
+        assertThrows(KeeperException.NoNodeException.class, () -> curator.getData().forPath("/some/path/or/another"));
+        assertEquals(newArrayList("or"), curator.getChildren().forPath("/some/path"));
+    }
+
+    private void createNode(String path) throws Exception {
+        curator.create().creatingParentsIfNeeded().forPath(path);
+    }
+
+    private void createNodeWithData(String path, String data) throws Exception {
+        curator.create().creatingParentsIfNeeded().forPath(path, data.getBytes());
+    }
+}

--- a/src/test/java/com/flightstats/hub/webhook/ActiveWebhookSweeperTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/ActiveWebhookSweeperTest.java
@@ -1,0 +1,44 @@
+package com.flightstats.hub.webhook;
+
+import org.junit.Test;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Sets.newHashSet;
+import static java.util.Collections.emptyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ActiveWebhookSweeperTest {
+    private static final String WEBHOOK_WITH_LEASE = "withLease";
+    private static final String WEBHOOK_WITH_A_FEW_LEASES = "severalLeases";
+    private static final String WEBHOOK_WITH_LOCK = "withLock";
+    private static final String EMPTY_WEBHOOK = "gotNothing";
+
+    private final WebhookLeaderLocks webhookLeaderLocks = mock(WebhookLeaderLocks.class);
+
+    @Test
+    public void testCleanupEmpty_keepsWebhooksWithLeasesAndLocksAndDiscardsOthers() throws Exception {
+        when(webhookLeaderLocks.getWebhooks())
+                .thenReturn(newHashSet(WEBHOOK_WITH_A_FEW_LEASES, WEBHOOK_WITH_LEASE, WEBHOOK_WITH_LOCK, EMPTY_WEBHOOK));
+
+        when(webhookLeaderLocks.getLeasePaths(WEBHOOK_WITH_LEASE)).thenReturn(newArrayList("lease1"));
+        when(webhookLeaderLocks.getLeasePaths(WEBHOOK_WITH_A_FEW_LEASES)).thenReturn(newArrayList("lease1b", "lease2b"));
+        when(webhookLeaderLocks.getLeasePaths(WEBHOOK_WITH_LOCK)).thenReturn(emptyList());
+        when(webhookLeaderLocks.getLeasePaths(EMPTY_WEBHOOK)).thenReturn(emptyList());
+
+        when(webhookLeaderLocks.getLockPaths(WEBHOOK_WITH_LEASE)).thenReturn(newArrayList("lock1"));
+        when(webhookLeaderLocks.getLockPaths(WEBHOOK_WITH_A_FEW_LEASES)).thenReturn(emptyList());
+        when(webhookLeaderLocks.getLockPaths(WEBHOOK_WITH_LOCK)).thenReturn(newArrayList("lock1b"));
+        when(webhookLeaderLocks.getLockPaths(EMPTY_WEBHOOK)).thenReturn(emptyList());
+
+        ActiveWebhookSweeper sweeper = new ActiveWebhookSweeper(webhookLeaderLocks);
+        sweeper.cleanupEmpty();
+
+        verify(webhookLeaderLocks, never()).deleteWebhookLeader(WEBHOOK_WITH_A_FEW_LEASES);
+        verify(webhookLeaderLocks, never()).deleteWebhookLeader(WEBHOOK_WITH_LEASE);
+        verify(webhookLeaderLocks, never()).deleteWebhookLeader(WEBHOOK_WITH_LOCK);
+        verify(webhookLeaderLocks).deleteWebhookLeader(EMPTY_WEBHOOK);
+    }
+}

--- a/src/test/java/com/flightstats/hub/webhook/ActiveWebhookSweeperTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/ActiveWebhookSweeperTest.java
@@ -1,5 +1,6 @@
 package com.flightstats.hub.webhook;
 
+import com.flightstats.hub.metrics.MetricsService;
 import org.junit.Test;
 
 import static com.google.common.collect.Lists.newArrayList;
@@ -17,6 +18,7 @@ public class ActiveWebhookSweeperTest {
     private static final String EMPTY_WEBHOOK = "gotNothing";
 
     private final WebhookLeaderLocks webhookLeaderLocks = mock(WebhookLeaderLocks.class);
+    private final MetricsService metricsService = mock(MetricsService.class);
 
     @Test
     public void testCleanupEmpty_keepsWebhooksWithLeasesAndLocksAndDiscardsOthers() throws Exception {
@@ -33,12 +35,14 @@ public class ActiveWebhookSweeperTest {
         when(webhookLeaderLocks.getLockPaths(WEBHOOK_WITH_LOCK)).thenReturn(newArrayList("lock1b"));
         when(webhookLeaderLocks.getLockPaths(EMPTY_WEBHOOK)).thenReturn(emptyList());
 
-        ActiveWebhookSweeper sweeper = new ActiveWebhookSweeper(webhookLeaderLocks);
+        ActiveWebhookSweeper sweeper = new ActiveWebhookSweeper(webhookLeaderLocks, metricsService);
         sweeper.cleanupEmpty();
 
         verify(webhookLeaderLocks, never()).deleteWebhookLeader(WEBHOOK_WITH_A_FEW_LEASES);
         verify(webhookLeaderLocks, never()).deleteWebhookLeader(WEBHOOK_WITH_LEASE);
         verify(webhookLeaderLocks, never()).deleteWebhookLeader(WEBHOOK_WITH_LOCK);
         verify(webhookLeaderLocks).deleteWebhookLeader(EMPTY_WEBHOOK);
+
+        verify(metricsService).count("webhook.leaders.cleanup", 1);
     }
 }

--- a/src/test/java/com/flightstats/hub/webhook/ActiveWebhooksTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/ActiveWebhooksTest.java
@@ -1,15 +1,8 @@
 package com.flightstats.hub.webhook;
 
 import com.flightstats.hub.app.HubHost;
-import com.flightstats.hub.test.Integration;
-import com.flightstats.hub.util.SafeZooKeeperUtils;
-import org.apache.curator.framework.CuratorFramework;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -18,13 +11,13 @@ import static java.lang.String.format;
 import static java.util.stream.Collectors.toSet;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.testng.AssertJUnit.assertTrue;
 
 public class ActiveWebhooksTest {
-    private static final String WEBHOOK_LEADER_PATH = "/WebhookLeader";
     private static final int HUB_PORT = HubHost.getLocalPort();
-
 
     private static final String WEBHOOK_WITH_LEASE = "webhook1";
     private static final String WEBHOOK_WITH_A_FEW_LEASES = "webhook4";
@@ -34,145 +27,56 @@ public class ActiveWebhooksTest {
     private static final String SERVER_IP1 = "10.2.1";
     private static final String SERVER_IP2 = "10.2.2";
 
-    private static CuratorFramework curator;
-    private static SafeZooKeeperUtils zooKeeperUtils;
+    private final WebhookLeaderLocks webhookLeaderLocks = mock(WebhookLeaderLocks.class);
+    private final ActiveWebhookSweeper activeWebhookSweeper = mock(ActiveWebhookSweeper.class);
 
-    @BeforeClass
-    public static void setup() throws Exception {
-        curator = Integration.startZooKeeper();
-        zooKeeperUtils = new SafeZooKeeperUtils(curator);
-    }
+    @Test
+    public void testInitialize_cleansUpWebhooks() {
+        new ActiveWebhooks(webhookLeaderLocks, activeWebhookSweeper);
 
-    @Before
-    public void createWebhookLeader() throws Exception {
-        curator.create().creatingParentsIfNeeded().forPath(WEBHOOK_LEADER_PATH);
-    }
-
-    @After
-    public void destroyWebhookLeaders() throws Exception {
-        curator.delete().deletingChildrenIfNeeded().forPath(WEBHOOK_LEADER_PATH);
+        verify(activeWebhookSweeper).cleanupEmpty();
     }
 
     @Test
-    public void testCleanupEmpty_keepsWebhooksWithLeasesAndLocksAndDiscardsOthers() throws Exception {
-        createWebhookLease(WEBHOOK_WITH_A_FEW_LEASES, "someLease", SERVER_IP1);
-        createWebhookLease(WEBHOOK_WITH_A_FEW_LEASES, "someLease2", SERVER_IP2);
-        createWebhookLease(WEBHOOK_WITH_A_FEW_LEASES, "someLease3", SERVER_IP2);
+    public void testGetServers_returnsSeveralForAWebhook() throws Exception {
+        when(webhookLeaderLocks.getServerLeases(WEBHOOK_WITH_A_FEW_LEASES))
+                .thenReturn(newHashSet(SERVER_IP2, SERVER_IP1));
 
-        createWebhookLock(WEBHOOK_WITH_LEASE, "someLock", "");
-        createWebhookLease(WEBHOOK_WITH_LEASE, "someLease", SERVER_IP1);
-
-        createWebhookLock(WEBHOOK_WITH_LOCK, "aLock", "???");
-
-        createWebhook(EMPTY_WEBHOOK);
-
-        ActiveWebhooks activeWebhooks = new ActiveWebhooks(zooKeeperUtils);
-        activeWebhooks.cleanupEmpty();
-
-        List<String> webhooks = curator.getChildren().forPath(WEBHOOK_LEADER_PATH);
-        assertEquals(3, webhooks.size());
-        assertEquals(newHashSet(WEBHOOK_WITH_LOCK, WEBHOOK_WITH_A_FEW_LEASES, WEBHOOK_WITH_LEASE), newHashSet(webhooks));
-
-        assertTrue(activeWebhooks.isActiveWebhook(WEBHOOK_WITH_A_FEW_LEASES));
-        assertTrue(activeWebhooks.isActiveWebhook(WEBHOOK_WITH_LEASE));
-        assertTrue(activeWebhooks.isActiveWebhook(WEBHOOK_WITH_LOCK));
-
-        assertFalse(activeWebhooks.isActiveWebhook(EMPTY_WEBHOOK));
-    }
-
-    @Test
-    public void testGetServers_returnsSeveralDistinctServersForAWebhook() throws Exception {
-        createWebhookLease(WEBHOOK_WITH_A_FEW_LEASES, "someLease", SERVER_IP1);
-        createWebhookLease(WEBHOOK_WITH_A_FEW_LEASES, "someLease2", SERVER_IP2);
-        createWebhookLease(WEBHOOK_WITH_A_FEW_LEASES, "someLease3", SERVER_IP2);
-
-        ActiveWebhooks activeWebhooks = new ActiveWebhooks(zooKeeperUtils);
+        ActiveWebhooks activeWebhooks = new ActiveWebhooks(webhookLeaderLocks, activeWebhookSweeper);
         Set<String> servers = activeWebhooks.getServers(WEBHOOK_WITH_A_FEW_LEASES);
+
         assertEquals(getServersWithPort(SERVER_IP1, SERVER_IP2), servers);
     }
 
-    @Test
-    public void testGetServers_returnsSingleServerForAWebhook() throws Exception {
-        createWebhookLock(WEBHOOK_WITH_LEASE, "someLock", "");
-        createWebhookLease(WEBHOOK_WITH_LEASE, "someLease", SERVER_IP1);
-
-        ActiveWebhooks activeWebhooks = new ActiveWebhooks(zooKeeperUtils);
-        Set<String> servers = activeWebhooks.getServers(WEBHOOK_WITH_LEASE);
-        assertEquals(getServersWithPort(SERVER_IP1), servers);
-    }
 
     @Test
-    public void testGetServers_returnsAnEmptyListIfThereAreNoLeases()  throws Exception {
-        createWebhookLock(WEBHOOK_WITH_LOCK, "aLock", "???");
+    public void testGetServers_returnsAnEmptyListIfThereAreNoLeases() throws Exception {
+        when(webhookLeaderLocks.getServerLeases(EMPTY_WEBHOOK))
+                .thenReturn(newHashSet());
 
-        ActiveWebhooks activeWebhooks = new ActiveWebhooks(zooKeeperUtils);
-        Set<String> servers = activeWebhooks.getServers(WEBHOOK_WITH_LOCK);
-        assertEquals(newHashSet(), servers);
-    }
-
-    @Test
-    public void testGetServers_returnsAnEmptyListIfTheWebhookWasEmpty() throws Exception{
-        createWebhook(EMPTY_WEBHOOK);
-
-        ActiveWebhooks activeWebhooks = new ActiveWebhooks(zooKeeperUtils);
+        ActiveWebhooks activeWebhooks = new ActiveWebhooks(webhookLeaderLocks, activeWebhookSweeper);
         Set<String> servers = activeWebhooks.getServers(EMPTY_WEBHOOK);
+
         assertEquals(newHashSet(), servers);
     }
 
     @Test
-    public void testGetServers_returnsAnEmptyListForNonExistentWebhook() throws Exception {
-        ActiveWebhooks activeWebhooks = new ActiveWebhooks(zooKeeperUtils);
-        Set<String> servers = activeWebhooks.getServers("bogusWebhook");
-        assertEquals(newHashSet(), servers);
-    }
+    public void testIsActiveWebhook_isTrueIfWebhookIsPresent() throws Exception {
+        when(webhookLeaderLocks.getWebhooks())
+                .thenReturn(newHashSet(WEBHOOK_WITH_A_FEW_LEASES, WEBHOOK_WITH_LEASE, WEBHOOK_WITH_LOCK));
 
-    @Test
-    public void testIsActiveWebhook_isTrueIfWebhookHasLease() throws Exception {
-        createWebhookLock(WEBHOOK_WITH_LEASE, "someLock", "");
-        createWebhookLease(WEBHOOK_WITH_LEASE, "someLease", SERVER_IP1);
-
-        ActiveWebhooks activeWebhooks = new ActiveWebhooks(zooKeeperUtils);
+        ActiveWebhooks activeWebhooks = new ActiveWebhooks(webhookLeaderLocks, activeWebhookSweeper);
         assertTrue(activeWebhooks.isActiveWebhook(WEBHOOK_WITH_LEASE));
     }
 
-    @Test
-    public void testIsActiveWebhook_isTrueIfWebhookHasLock() throws Exception {
-        createWebhookLock(WEBHOOK_WITH_LOCK, "aLock", "???");
-
-        ActiveWebhooks activeWebhooks = new ActiveWebhooks(zooKeeperUtils);
-        assertTrue(activeWebhooks.isActiveWebhook(WEBHOOK_WITH_LOCK));
-    }
 
     @Test
-    public void testIsActiveWebhook_isFalseIfWebhookIsEmptyAndHasBeenCleanedUp() throws Exception{
-        ActiveWebhooks activeWebhooks = new ActiveWebhooks(zooKeeperUtils);
-        assertFalse(activeWebhooks.isActiveWebhook("nonexistent webhook"));
-    }
+    public void testIsActiveWebhook_isFalseIfWebhookIsNotPresent() throws Exception{
+        when(webhookLeaderLocks.getWebhooks())
+                .thenReturn(newHashSet(WEBHOOK_WITH_A_FEW_LEASES, WEBHOOK_WITH_LEASE, WEBHOOK_WITH_LOCK));
 
-    private static void createWebhook(String webhook) {
-        try {
-            curator.create().creatingParentsIfNeeded().forPath(format("%s/%s/locks", WEBHOOK_LEADER_PATH, webhook), "".getBytes());
-            curator.create().creatingParentsIfNeeded().forPath(format("%s/%s/leases", WEBHOOK_LEADER_PATH, webhook), "".getBytes());
-        } catch(Exception e) {
-            fail(e.getMessage());
-        }
-    }
-
-    private static void createWebhookLock(String webhook, String lockName, String value) {
-        try {
-            curator.create().creatingParentsIfNeeded().forPath(format("%s/%s/locks/%s", WEBHOOK_LEADER_PATH, webhook, lockName), value.getBytes());
-        } catch(Exception e) {
-            fail(e.getMessage());
-        }
-    }
-
-    private static void createWebhookLease(String webhook, String leaseName, String value) {
-        String leasePath = format("%s/%s/leases/%s", WEBHOOK_LEADER_PATH, webhook, leaseName);
-        try {
-            curator.create().creatingParentsIfNeeded().forPath(leasePath, value.getBytes());
-        } catch(Exception e) {
-            fail(e.getMessage());
-        }
+        ActiveWebhooks activeWebhooks = new ActiveWebhooks(webhookLeaderLocks, activeWebhookSweeper);
+        assertFalse(activeWebhooks.isActiveWebhook(EMPTY_WEBHOOK));
     }
 
     private Set<String> getServersWithPort(String... servers) {

--- a/src/test/java/com/flightstats/hub/webhook/ActiveWebhooksTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/ActiveWebhooksTest.java
@@ -12,7 +12,6 @@ import static java.util.stream.Collectors.toSet;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.AssertJUnit.assertTrue;
 
@@ -29,13 +28,6 @@ public class ActiveWebhooksTest {
 
     private final WebhookLeaderLocks webhookLeaderLocks = mock(WebhookLeaderLocks.class);
     private final ActiveWebhookSweeper activeWebhookSweeper = mock(ActiveWebhookSweeper.class);
-
-    @Test
-    public void testInitialize_cleansUpWebhooks() {
-        new ActiveWebhooks(webhookLeaderLocks, activeWebhookSweeper);
-
-        verify(activeWebhookSweeper).cleanupEmpty();
-    }
 
     @Test
     public void testGetServers_returnsSeveralForAWebhook() throws Exception {

--- a/src/test/java/com/flightstats/hub/webhook/WebhookContentPathSetTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/WebhookContentPathSetTest.java
@@ -3,6 +3,7 @@ package com.flightstats.hub.webhook;
 import com.flightstats.hub.model.ContentKey;
 import com.flightstats.hub.model.ContentPath;
 import com.flightstats.hub.test.Integration;
+import com.flightstats.hub.util.SafeZooKeeperUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.junit.Before;
 import org.junit.Test;
@@ -10,21 +11,22 @@ import org.junit.Test;
 import java.util.Set;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
 
 public class WebhookContentPathSetTest {
-
-    private CuratorFramework curator;
+    private SafeZooKeeperUtils zooKeeperUtils;
     private WebhookContentPathSet groupSet;
     private String groupName;
 
     @Before
     public void setUp() throws Exception {
-        curator = Integration.startZooKeeper();
+        CuratorFramework curator = Integration.startZooKeeper();
+        zooKeeperUtils = new SafeZooKeeperUtils(curator);
     }
 
     @Test
     public void testLifecycle() throws Exception {
-        groupSet = new WebhookContentPathSet(curator);
+        groupSet = new WebhookContentPathSet(zooKeeperUtils);
         ContentKey first = new ContentKey();
         ContentKey second = new ContentKey();
         ContentKey third = new ContentKey();
@@ -53,7 +55,7 @@ public class WebhookContentPathSetTest {
 
     @Test
     public void testDelete() throws Exception {
-        groupSet = new WebhookContentPathSet(curator);
+        groupSet = new WebhookContentPathSet(zooKeeperUtils);
         groupName = "testDelete";
         ContentKey contentKey = new ContentKey();
         addAndCompare(contentKey, 1);

--- a/src/test/java/com/flightstats/hub/webhook/WebhookContentPathSetTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/WebhookContentPathSetTest.java
@@ -11,7 +11,6 @@ import org.junit.Test;
 import java.util.Set;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
 
 public class WebhookContentPathSetTest {
     private SafeZooKeeperUtils zooKeeperUtils;

--- a/src/test/java/com/flightstats/hub/webhook/WebhookLeaderLocksTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/WebhookLeaderLocksTest.java
@@ -1,0 +1,242 @@
+package com.flightstats.hub.webhook;
+
+import com.flightstats.hub.cluster.ZooKeeperState;
+import com.flightstats.hub.test.Integration;
+import com.flightstats.hub.util.SafeZooKeeperUtils;
+import org.apache.curator.framework.CuratorFramework;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Sets.newHashSet;
+import static java.lang.String.format;
+import static java.util.Collections.emptyList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class WebhookLeaderLocksTest {
+    private static final String WEBHOOK_LEADER_PATH = "/WebhookLeader";
+
+    private static final String WEBHOOK_WITH_LEASE = "webhook1";
+    private static final String WEBHOOK_WITH_A_FEW_LEASES = "webhook4";
+    private static final String WEBHOOK_WITH_LOCK = "webhook3";
+    private static final String EMPTY_WEBHOOK = "webhook2";
+
+    private static final String SERVER_IP1 = "10.2.1";
+    private static final String SERVER_IP2 = "10.2.2";
+
+    private static CuratorFramework curator;
+    private static SafeZooKeeperUtils zooKeeperUtils;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        ZooKeeperState zooKeeperState = new ZooKeeperState();
+        curator = Integration.startZooKeeper();
+        zooKeeperUtils = new SafeZooKeeperUtils(curator);
+    }
+
+    @Before
+    public void createWebhookLeader() throws Exception {
+        curator.create().creatingParentsIfNeeded().forPath(WEBHOOK_LEADER_PATH);
+    }
+
+    @After
+    public void destroyWebhookLeaders() throws Exception {
+        curator.delete().deletingChildrenIfNeeded().forPath(WEBHOOK_LEADER_PATH);
+    }
+
+    @Test
+    public void testDeleteWebhook() throws Exception {
+        createWebhook(EMPTY_WEBHOOK);
+
+        createWebhookLock(WEBHOOK_WITH_A_FEW_LEASES, "someLock", SERVER_IP1);
+        createWebhookLease(WEBHOOK_WITH_A_FEW_LEASES, "someLease2", SERVER_IP2);
+        createWebhookLease(WEBHOOK_WITH_A_FEW_LEASES, "someLease3", SERVER_IP2);
+
+        List<String> initialWebhooks = curator.getChildren().forPath(WEBHOOK_LEADER_PATH);
+        assertEquals("givens should have created 2 webhooks", 2, initialWebhooks.size());
+
+        WebhookLeaderLocks webhookLeaderLocks = new WebhookLeaderLocks(zooKeeperUtils);
+        webhookLeaderLocks.deleteWebhookLeader(WEBHOOK_WITH_A_FEW_LEASES);
+
+        List<String> webhooks = curator.getChildren().forPath(WEBHOOK_LEADER_PATH);
+        assertEquals(1, webhooks.size());
+        assertEquals(newHashSet(EMPTY_WEBHOOK), newHashSet(webhooks));
+    }
+
+    @Test
+    public void testGetServers_returnsSeveralDistinctServersForAWebhook() throws Exception {
+        createWebhookLease(WEBHOOK_WITH_A_FEW_LEASES, "someLease", SERVER_IP1);
+        createWebhookLease(WEBHOOK_WITH_A_FEW_LEASES, "someLease2", SERVER_IP2);
+        createWebhookLease(WEBHOOK_WITH_A_FEW_LEASES, "someLease3", SERVER_IP2);
+
+        WebhookLeaderLocks webhookLeaderLocks = new WebhookLeaderLocks(zooKeeperUtils);
+        Set<String> servers = webhookLeaderLocks.getServerLeases(WEBHOOK_WITH_A_FEW_LEASES);
+
+        assertEquals(newHashSet(SERVER_IP1, SERVER_IP2), servers);
+    }
+
+    @Test
+    public void testGetServers_returnsSingleServerForAWebhook() throws Exception {
+        createWebhookLock(WEBHOOK_WITH_LEASE, "someLock", "");
+        createWebhookLease(WEBHOOK_WITH_LEASE, "someLease", SERVER_IP1);
+
+        WebhookLeaderLocks webhookLeaders = new WebhookLeaderLocks(zooKeeperUtils);
+        Set<String> servers = webhookLeaders.getServerLeases(WEBHOOK_WITH_LEASE);
+
+        assertEquals(newHashSet(SERVER_IP1), servers);
+    }
+
+    @Test
+    public void testGetServers_returnsAnEmptyListIfThereAreNoLeases()  throws Exception {
+        createWebhookLock(WEBHOOK_WITH_LOCK, "aLock", "???");
+
+        WebhookLeaderLocks webhookLeaders = new WebhookLeaderLocks(zooKeeperUtils);
+        Set<String> servers = webhookLeaders.getServerLeases(WEBHOOK_WITH_LOCK);
+
+        assertEquals(newHashSet(), servers);
+    }
+
+    @Test
+    public void testGetServers_returnsAnEmptyListIfTheWebhookWasEmpty() throws Exception{
+        createWebhook(EMPTY_WEBHOOK);
+
+        WebhookLeaderLocks webhookLeaders = new WebhookLeaderLocks(zooKeeperUtils);
+        Set<String> servers = webhookLeaders.getServerLeases(EMPTY_WEBHOOK);
+
+        assertEquals(newHashSet(), servers);
+    }
+
+    @Test
+    public void testGetServers_returnsAnEmptyListForNonExistentWebhook() throws Exception {
+        WebhookLeaderLocks webhookLeaders = new WebhookLeaderLocks(zooKeeperUtils);
+        Set<String> servers = webhookLeaders.getServerLeases("bogusWebhook");
+
+        assertEquals(newHashSet(), servers);
+    }
+
+    @Test
+    public void testGetWebhooks_returnsAllWebhooksRegardlessOfLocksOrLeases() throws Exception {
+        createWebhookLease(WEBHOOK_WITH_A_FEW_LEASES, "someLease", SERVER_IP1);
+        createWebhookLease(WEBHOOK_WITH_A_FEW_LEASES, "someLease2", SERVER_IP2);
+        createWebhookLease(WEBHOOK_WITH_A_FEW_LEASES, "someLease3", SERVER_IP2);
+
+        createWebhookLock(WEBHOOK_WITH_LEASE, "someLock", "");
+        createWebhookLease(WEBHOOK_WITH_LEASE, "someLease", SERVER_IP1);
+
+        createWebhookLock(WEBHOOK_WITH_LOCK, "aLock", "???");
+
+        createWebhook(EMPTY_WEBHOOK);
+
+        WebhookLeaderLocks webhookLeaders = new WebhookLeaderLocks(zooKeeperUtils);
+        Set<String> webhooks = webhookLeaders.getWebhooks();
+        assertEquals(newHashSet(WEBHOOK_WITH_A_FEW_LEASES, WEBHOOK_WITH_LEASE, WEBHOOK_WITH_LOCK, EMPTY_WEBHOOK), webhooks);
+    }
+
+    @Test
+    public void testGetLocks() throws Exception {
+        createWebhookLock(WEBHOOK_WITH_LOCK, "someLock", "");
+        createWebhookLease(WEBHOOK_WITH_LOCK, "someLease", SERVER_IP1);
+
+        WebhookLeaderLocks webhookLeaders = new WebhookLeaderLocks(zooKeeperUtils);
+        List<String> locks = webhookLeaders.getLockPaths(WEBHOOK_WITH_LOCK);
+
+        assertEquals(newArrayList("someLock"), locks);
+    }
+
+    @Test
+    public void testGetLocks_withNoLocks() throws Exception {
+        createWebhookLease(WEBHOOK_WITH_LEASE, "someLease", SERVER_IP1);
+
+        WebhookLeaderLocks webhookLeaders = new WebhookLeaderLocks(zooKeeperUtils);
+        List<String> locks = webhookLeaders.getLockPaths(WEBHOOK_WITH_LEASE);
+
+        assertEquals(emptyList(), locks);
+    }
+
+    @Test
+    public void testGetLocks_noWebhook() throws Exception {
+        WebhookLeaderLocks webhookLeaders = new WebhookLeaderLocks(zooKeeperUtils);
+        List<String> locks = webhookLeaders.getLockPaths("dunno");
+
+        assertEquals(emptyList(), locks);
+    }
+
+    @Test
+    public void testGetLeases() throws Exception {
+        createWebhookLock(WEBHOOK_WITH_A_FEW_LEASES, "someLock", "");
+        createWebhookLease(WEBHOOK_WITH_A_FEW_LEASES, "someLease", SERVER_IP1);
+        createWebhookLease(WEBHOOK_WITH_A_FEW_LEASES, "someLease2", SERVER_IP2);
+        createWebhookLease(WEBHOOK_WITH_A_FEW_LEASES, "someLease3", SERVER_IP1);
+
+        WebhookLeaderLocks webhookLeaders = new WebhookLeaderLocks(zooKeeperUtils);
+        List<String> leases = webhookLeaders.getLeasePaths(WEBHOOK_WITH_A_FEW_LEASES);
+
+        assertEquals(3, leases.size());
+        assertEquals(newHashSet("someLease", "someLease2", "someLease3"), newHashSet(leases));
+    }
+
+    @Test
+    public void testGetLeases_withNoLeases() throws Exception {
+        createWebhookLock(WEBHOOK_WITH_LOCK, "someLock", "");
+
+        WebhookLeaderLocks webhookLeaders = new WebhookLeaderLocks(zooKeeperUtils);
+        List<String> leases = webhookLeaders.getLeasePaths(WEBHOOK_WITH_LOCK);
+
+        assertEquals(emptyList(), leases);
+    }
+
+    @Test
+    public void testGetLeases_noWebhook() throws Exception {
+        WebhookLeaderLocks webhookLeaders = new WebhookLeaderLocks(zooKeeperUtils);
+        List<String> leases = webhookLeaders.getLeasePaths("dunno");
+
+        assertEquals(emptyList(), leases);
+    }
+
+    private static void createWebhook(String webhook) {
+        try {
+            curator.create().creatingParentsIfNeeded().forPath(getLeasePath(webhook), "".getBytes());
+            curator.create().creatingParentsIfNeeded().forPath(getLockPath(webhook), "".getBytes());
+        } catch(Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    private static void createWebhookLock(String webhook, String lockName, String value) {
+        try {
+            curator.create().creatingParentsIfNeeded().forPath(getLockPath(webhook, lockName), value.getBytes());
+        } catch(Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    private static void createWebhookLease(String webhook, String leaseName, String value) {
+        try {
+            curator.create().creatingParentsIfNeeded().forPath(getLeasePath(webhook, leaseName), value.getBytes());
+        } catch(Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    private static String getLockPath(String webhook) {
+        return format("%s/%s/locks", WEBHOOK_LEADER_PATH, webhook);
+    }
+
+    private static String getLockPath(String webhook, String lockName) {
+        return format("%s/%s", getLockPath(webhook), lockName);
+    }
+
+    private static String getLeasePath(String webhook) {
+        return format("%s/%s/leases", WEBHOOK_LEADER_PATH, webhook);
+    }
+
+    private static String getLeasePath(String webhook, String leaseName) {
+        return format("%s/%s", getLeasePath(webhook), leaseName);
+    }
+}


### PR DESCRIPTION
I restructured my commits a bit and moved up some of the refactoring I did later. I noticed a pattern where we wrap ZK curator calls in try/catch blocks and ignore errors, so that's extracted out into its own thing. It includes common actions that I noticed, some of which aren't immediately used (though I believe they're all tested).

I'd recommend looking at the PR commit-by-commit rather than all of it at once, though if it would be more digestible, I can split this into 2 PRs -- one for the first 3 commits that DRY up the ZK interactions and one for actually cleaning up inactive webhook leaders. 

There's one (or maybe 2?) more PRs after this, which ensures we uniformly clean up all the ZK stuff when we delete a webhook. That PR would also include some refactoring and more thorough testing of WebhookError.