### PR TITLE
Uniformly remove all zk cruft when we delete a webhook

### DIFF
--- a/src/main/java/com/flightstats/hub/webhook/WebhookError.java
+++ b/src/main/java/com/flightstats/hub/webhook/WebhookError.java
@@ -5,25 +5,16 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.flightstats.hub.dao.ChannelService;
 import com.flightstats.hub.model.Content;
 import com.flightstats.hub.util.RequestUtils;
-import com.flightstats.hub.util.StringUtils;
-import com.flightstats.hub.util.TimeUtil;
-import com.flightstats.hub.util.SafeZooKeeperUtils;
-import com.google.common.annotations.VisibleForTesting;
+import com.flightstats.hub.webhook.error.WebhookErrorPruner;
+import com.flightstats.hub.webhook.error.WebhookErrorService;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import lombok.Builder;
-import lombok.Getter;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Duration;
 import java.util.List;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import static com.flightstats.hub.util.RequestUtils.getChannelName;
-import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -40,39 +31,41 @@ import static java.util.stream.Collectors.toList;
 @Singleton
 class WebhookError {
     private final static Logger logger = LoggerFactory.getLogger(WebhookError.class);
-    private static final String BASE_PATH = "/GroupError";
 
-    private final SafeZooKeeperUtils zooKeeperUtils;
+    private final WebhookErrorService webhookErrorService;
     private final ChannelService channelService;
-    private final ErrorNodeNameGenerator errorNameGenerator;
-    private final WebhookErrorReaper webhookErrorReaper;
+    private final WebhookErrorPruner webhookErrorPruner;
 
     @Inject
-    public WebhookError(SafeZooKeeperUtils zooKeeperUtils, ChannelService channelService) {
-        this(zooKeeperUtils, channelService, new ErrorNodeNameGenerator(), new WebhookErrorReaper(zooKeeperUtils));
-    }
-
-    @VisibleForTesting
-    public WebhookError(SafeZooKeeperUtils zooKeeperUtils, ChannelService channelService, ErrorNodeNameGenerator errorNameGenerator, WebhookErrorReaper errorReaper) {
-        this.zooKeeperUtils = zooKeeperUtils;
+    public WebhookError(WebhookErrorService webhookErrorService, WebhookErrorPruner webhookErrorPruner, ChannelService channelService) {
+        this.webhookErrorService = webhookErrorService;
+        this.webhookErrorPruner = webhookErrorPruner;
         this.channelService = channelService;
-        this.errorNameGenerator = errorNameGenerator;
-        this.webhookErrorReaper = errorReaper;
     }
 
     public void add(String webhook, String error) {
-        zooKeeperUtils.createData(error.getBytes(), BASE_PATH, webhook, errorNameGenerator.generateName());
-        webhookErrorReaper.limitChildren(webhook);
+        webhookErrorService.add(webhook, error);
+        limitChildren(webhook);
     }
 
     public void delete(String webhook) {
         logger.info("deleting webhook errors for " + webhook);
-        zooKeeperUtils.deletePathAndChildren(BASE_PATH, webhook);
+        webhookErrorService.deleteWebhook(webhook);
     }
 
     public List<String> get(String webhook) {
-        return webhookErrorReaper.limitChildren(webhook).stream()
-                .map(Error::getData)
+        return limitChildren(webhook).stream()
+                .map(com.flightstats.hub.webhook.error.WebhookError::getData)
+                .collect(toList());
+    }
+
+    private List<com.flightstats.hub.webhook.error.WebhookError> limitChildren(String webhook) {
+        List<com.flightstats.hub.webhook.error.WebhookError> errors = webhookErrorService.getErrors(webhook);
+
+        List<com.flightstats.hub.webhook.error.WebhookError> prunedErrors = webhookErrorPruner.pruneErrors(webhook, errors);
+
+        return errors.stream()
+                .filter(error -> !prunedErrors.contains(error))
                 .collect(toList());
     }
 
@@ -126,74 +119,5 @@ class WebhookError {
         int firstSpace = error.indexOf(" ");
         int secondSpace = error.indexOf(" ", firstSpace + 1);
         return error.substring(secondSpace + 1);
-    }
-
-    @VisibleForTesting
-    static class ErrorNodeNameGenerator {
-        String generateName() {
-            return TimeUtil.now().getMillis() + StringUtils.randomAlphaNumeric(6);
-        }
-    }
-
-    @Builder
-    @Getter
-    private static class Error {
-        String name;
-        DateTime creationTime;
-        String data;
-    }
-
-    static class WebhookErrorReaper {
-        private static final int MAX_SIZE = 10;
-        private static final Duration MAX_AGE = Duration.ofDays(1);
-
-        private final SafeZooKeeperUtils zooKeeperUtils;
-
-        @Inject
-        WebhookErrorReaper(SafeZooKeeperUtils zooKeeperUtils) {
-            this.zooKeeperUtils = zooKeeperUtils;
-        }
-
-        List<Error> limitChildren(String webhook) {
-            try {
-                List<Error> errors = getChildren(webhook);
-                List<Error> errorsToDelete = getErrorsToRemove(errors);
-
-                errorsToDelete.forEach(error -> zooKeeperUtils.deletePathInBackground(BASE_PATH, webhook, error.getName()));
-
-                return errors.stream()
-                        .filter(error -> !errorsToDelete.contains(error))
-                        .collect(toList());
-            } catch (Exception e) {
-                logger.warn("unable to limit webhook error children " + webhook, e);
-            }
-            return emptyList();
-        }
-
-        private List<Error> getChildren(String webhook) {
-             return zooKeeperUtils.getChildren(BASE_PATH, webhook).stream()
-                    .map(child -> zooKeeperUtils.getDataWithStat(BASE_PATH, webhook, child)
-                            .map(dataWithStat -> Error.builder()
-                                    .name(child)
-                                    .creationTime(new DateTime(dataWithStat.getStat().getCtime()))
-                                    .data(dataWithStat.getData())
-                                    .build()))
-                    .flatMap(maybeData -> maybeData.map(Stream::of).orElse(Stream.empty()))
-                    .collect(toList());
-
-        }
-
-        private List<Error> getErrorsToRemove(List<Error> errors) {
-            return IntStream.range(0, errors.size())
-                    .filter(errorIndex -> shouldRemoveError(errors, errorIndex))
-                    .mapToObj(errors::get)
-                    .collect(toList());
-        }
-
-        private boolean shouldRemoveError(List<Error> errors, int errorIndex) {
-            DateTime cutoffTime = TimeUtil.now().minus(MAX_AGE.toMillis());
-            int maxErrorIndexToDelete = errors.size() - MAX_SIZE;
-            return errorIndex < maxErrorIndexToDelete || errors.get(errorIndex).getCreationTime().isBefore(cutoffTime);
-        }
     }
 }

--- a/src/main/java/com/flightstats/hub/webhook/WebhookLeader.java
+++ b/src/main/java/com/flightstats/hub/webhook/WebhookLeader.java
@@ -11,6 +11,7 @@ import com.flightstats.hub.util.Sleeper;
 import com.flightstats.hub.util.TimeUtil;
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
+import org.apache.curator.framework.CuratorFramework;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,7 +26,6 @@ import static com.flightstats.hub.webhook.WebhookLeaderLocks.WEBHOOK_LEADER;
 class WebhookLeader implements Lockable {
     private final static Logger logger = LoggerFactory.getLogger(WebhookLeader.class);
     static final String WEBHOOK_LAST_COMPLETED = "/GroupLastCompleted/";
-    public static final String LEADER_PATH = "/WebhookLeader";
 
     private final AtomicBoolean deleteOnExit = new AtomicBoolean();
 

--- a/src/main/java/com/flightstats/hub/webhook/WebhookLeaderLocks.java
+++ b/src/main/java/com/flightstats/hub/webhook/WebhookLeaderLocks.java
@@ -15,7 +15,7 @@ import static java.util.stream.Collectors.toSet;
 
 @Singleton
 public class WebhookLeaderLocks {
-    private static final String WEBHOOK_LEADER = "/WebhookLeader";
+    static final String WEBHOOK_LEADER = "/WebhookLeader";
     private static final String LEASE_NODE = "leases";
     private static final String LOCK_NODE = "locks";
     private final SafeZooKeeperUtils zooKeeperUtils;

--- a/src/main/java/com/flightstats/hub/webhook/WebhookManager.java
+++ b/src/main/java/com/flightstats/hub/webhook/WebhookManager.java
@@ -53,6 +53,9 @@ public class WebhookManager {
     private InternalWebhookClient webhookClient;
 
     @Inject
+    private WebhookStateReaper webhookStateReaper;
+
+    @Inject
     public WebhookManager() {
         register(new WebhookIdleService(), HubServices.TYPE.AFTER_HEALTHY_START, HubServices.TYPE.PRE_STOP);
         register(new WebhookScheduledService(), HubServices.TYPE.AFTER_HEALTHY_START);
@@ -140,7 +143,7 @@ public class WebhookManager {
 
     public void delete(String name) {
         webhookClient.remove(name, activeWebhooks.getServers(name));
-        lastContentPath.delete(name, WebhookLeader.WEBHOOK_LAST_COMPLETED);
+        webhookStateReaper.delete(name);
     }
 
     public void getStatus(Webhook webhook, WebhookStatus.WebhookStatusBuilder statusBuilder) {

--- a/src/main/java/com/flightstats/hub/webhook/WebhookStateReaper.java
+++ b/src/main/java/com/flightstats/hub/webhook/WebhookStateReaper.java
@@ -1,0 +1,36 @@
+package com.flightstats.hub.webhook;
+
+import com.flightstats.hub.cluster.LastContentPath;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import static com.flightstats.hub.webhook.WebhookLeader.WEBHOOK_LAST_COMPLETED;
+
+@Singleton
+class WebhookStateReaper {
+    private final static Logger logger = LoggerFactory.getLogger(WebhookStateReaper.class);
+
+    private final LastContentPath lastContentPath;
+    private final WebhookContentPathSet webhookInProcess;
+    private final WebhookError webhookError;
+
+    @Inject
+    WebhookStateReaper(LastContentPath lastContentPath,
+                       WebhookContentPathSet webhookInProcess,
+                       WebhookError webhookError) {
+        this.lastContentPath = lastContentPath;
+        this.webhookInProcess = webhookInProcess;
+        this.webhookError = webhookError;
+    }
+
+    void delete(String webhook) {
+        logger.info("deleting " + webhook);
+        webhookInProcess.delete(webhook);
+        lastContentPath.delete(webhook, WEBHOOK_LAST_COMPLETED);
+        webhookError.delete(webhook);
+        logger.info("deleted " + webhook);
+    }
+}

--- a/src/main/java/com/flightstats/hub/webhook/error/WebhookError.java
+++ b/src/main/java/com/flightstats/hub/webhook/error/WebhookError.java
@@ -1,0 +1,13 @@
+package com.flightstats.hub.webhook.error;
+
+import lombok.Builder;
+import lombok.Value;
+import org.joda.time.DateTime;
+
+@Builder
+@Value
+public class WebhookError {
+    String name;
+    DateTime creationTime;
+    String data;
+}

--- a/src/main/java/com/flightstats/hub/webhook/error/WebhookErrorPruner.java
+++ b/src/main/java/com/flightstats/hub/webhook/error/WebhookErrorPruner.java
@@ -1,0 +1,44 @@
+package com.flightstats.hub.webhook.error;
+
+import com.flightstats.hub.util.TimeUtil;
+import org.joda.time.DateTime;
+
+import javax.inject.Inject;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static java.util.stream.Collectors.toList;
+
+public class WebhookErrorPruner {
+    private static final int MAX_SIZE = 10;
+    private static final Duration MAX_AGE = Duration.ofDays(1);
+
+    private final WebhookErrorService webhookErrorService;
+
+    @Inject
+    public WebhookErrorPruner(WebhookErrorService webhookErrorService) {
+        this.webhookErrorService = webhookErrorService;
+    }
+
+    public List<WebhookError> pruneErrors(String webhook, List<WebhookError> errors) {
+        List<com.flightstats.hub.webhook.error.WebhookError> errorsToRemove = getErrorsToRemove(errors);
+
+        errorsToRemove.forEach(error -> webhookErrorService.delete(webhook, error.getName()));
+
+        return errorsToRemove;
+    }
+
+    private List<WebhookError> getErrorsToRemove(List<WebhookError> errors) {
+        return IntStream.range(0, errors.size())
+                .filter(errorIndex -> shouldRemoveError(errors, errorIndex))
+                .mapToObj(errors::get)
+                .collect(toList());
+    }
+
+    private boolean shouldRemoveError(List<WebhookError> errors, int errorIndex) {
+        DateTime cutoffTime = TimeUtil.now().minus(MAX_AGE.toMillis());
+        int maxErrorIndexToDelete = errors.size() - MAX_SIZE;
+        return errorIndex < maxErrorIndexToDelete || errors.get(errorIndex).getCreationTime().isBefore(cutoffTime);
+    }
+}

--- a/src/main/java/com/flightstats/hub/webhook/error/WebhookErrorService.java
+++ b/src/main/java/com/flightstats/hub/webhook/error/WebhookErrorService.java
@@ -1,0 +1,74 @@
+package com.flightstats.hub.webhook.error;
+
+import com.flightstats.hub.util.SafeZooKeeperUtils;
+import com.flightstats.hub.util.StringUtils;
+import com.flightstats.hub.util.TimeUtil;
+import com.google.common.annotations.VisibleForTesting;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+
+public class WebhookErrorService {
+    private static final Logger logger = LoggerFactory.getLogger(WebhookErrorService.class);
+    private static final String BASE_PATH = "/GroupError";
+
+    private final SafeZooKeeperUtils zooKeeperUtils;
+    private final ErrorNodeNameGenerator errorNameGenerator;
+
+    @Inject
+    public WebhookErrorService(SafeZooKeeperUtils zooKeeperUtils) {
+        this.zooKeeperUtils = zooKeeperUtils;
+        this.errorNameGenerator = new ErrorNodeNameGenerator();
+    }
+
+    @VisibleForTesting
+    public WebhookErrorService(SafeZooKeeperUtils zooKeeperUtils, ErrorNodeNameGenerator errorNameGenerator) {
+        this.zooKeeperUtils = zooKeeperUtils;
+        this.errorNameGenerator = errorNameGenerator;
+    }
+
+    public void add(String webhook, String error) {
+        zooKeeperUtils.createData(error.getBytes(), BASE_PATH, webhook, errorNameGenerator.generateName());
+    }
+
+    public void deleteWebhook(String webhook) {
+        logger.info("deleting webhook errors for " + webhook);
+        zooKeeperUtils.deletePathAndChildren(BASE_PATH, webhook);
+    }
+
+    public void delete(String webhook, String errorId) {
+        zooKeeperUtils.deletePathInBackground(BASE_PATH, webhook, errorId);
+    }
+
+    public Set<String> getWebhooks() {
+        return new HashSet<>(zooKeeperUtils.getChildren(BASE_PATH));
+    }
+
+    public List<WebhookError> getErrors(String webhook) {
+        return zooKeeperUtils.getChildren(BASE_PATH, webhook).stream()
+                .map(child -> zooKeeperUtils.getDataWithStat(BASE_PATH, webhook, child)
+                        .map(dataWithStat -> WebhookError.builder()
+                                .name(child)
+                                .creationTime(new DateTime(dataWithStat.getStat().getCtime()))
+                                .data(dataWithStat.getData())
+                                .build()))
+                .flatMap(maybeData -> maybeData.map(Stream::of).orElse(Stream.empty()))
+                .collect(toList());
+
+    }
+
+    @VisibleForTesting
+    public static class ErrorNodeNameGenerator {
+        public String generateName() {
+            return TimeUtil.now().getMillis() + StringUtils.randomAlphaNumeric(6);
+        }
+    }
+}

--- a/src/test/java/com/flightstats/hub/webhook/WebhookErrorTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/WebhookErrorTest.java
@@ -1,9 +1,10 @@
 package com.flightstats.hub.webhook;
 
-import com.flightstats.hub.cluster.ZooKeeperState;
 import com.flightstats.hub.dao.ChannelService;
 import com.flightstats.hub.test.Integration;
 import com.flightstats.hub.util.SafeZooKeeperUtils;
+import com.flightstats.hub.webhook.error.WebhookErrorPruner;
+import com.flightstats.hub.webhook.error.WebhookErrorService;
 import org.apache.curator.framework.CuratorFramework;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -21,8 +22,10 @@ public class WebhookErrorTest {
     public static void setUpClass() throws Exception {
         ChannelService channelService = mock(ChannelService.class);
         CuratorFramework curator = Integration.startZooKeeper();
-        SafeZooKeeperUtils zooKeeperUtils = new SafeZooKeeperUtils(curator, mock(ZooKeeperState.class));
-        webhookError = new WebhookError(zooKeeperUtils, channelService);
+        SafeZooKeeperUtils zooKeeperUtils = new SafeZooKeeperUtils(curator);
+        WebhookErrorService webhookErrorService = new WebhookErrorService(zooKeeperUtils);
+        WebhookErrorPruner webhookErrorPruner = new WebhookErrorPruner(webhookErrorService);
+        webhookError = new WebhookError(webhookErrorService, webhookErrorPruner, channelService);
     }
 
     @Test

--- a/src/test/java/com/flightstats/hub/webhook/WebhookErrorTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/WebhookErrorTest.java
@@ -1,7 +1,9 @@
 package com.flightstats.hub.webhook;
 
+import com.flightstats.hub.cluster.ZooKeeperState;
 import com.flightstats.hub.dao.ChannelService;
 import com.flightstats.hub.test.Integration;
+import com.flightstats.hub.util.SafeZooKeeperUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -19,7 +21,8 @@ public class WebhookErrorTest {
     public static void setUpClass() throws Exception {
         ChannelService channelService = mock(ChannelService.class);
         CuratorFramework curator = Integration.startZooKeeper();
-        webhookError = new WebhookError(curator, channelService);
+        SafeZooKeeperUtils zooKeeperUtils = new SafeZooKeeperUtils(curator, mock(ZooKeeperState.class));
+        webhookError = new WebhookError(zooKeeperUtils, channelService);
     }
 
     @Test
@@ -37,5 +40,4 @@ public class WebhookErrorTest {
             assertEquals("stuff" + (i + 10), errors.get(i));
         }*/
     }
-
 }

--- a/src/test/java/com/flightstats/hub/webhook/WebhookErrorUnitTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/WebhookErrorUnitTest.java
@@ -1,102 +1,64 @@
 package com.flightstats.hub.webhook;
 
 import com.flightstats.hub.dao.ChannelService;
-import com.flightstats.hub.util.TimeUtil;
-import com.flightstats.hub.util.SafeZooKeeperUtils;
-import org.apache.zookeeper.data.Stat;
+import com.flightstats.hub.webhook.error.WebhookErrorPruner;
+import com.flightstats.hub.webhook.error.WebhookErrorService;
 import org.junit.Test;
 
-import java.time.Duration;
 import java.util.List;
-import java.util.Optional;
-import java.util.function.Function;
 import java.util.stream.IntStream;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class WebhookErrorUnitTest {
-    private final SafeZooKeeperUtils zooKeeperUtils = mock(SafeZooKeeperUtils.class);
     private final ChannelService channelService = mock(ChannelService.class);
-    private final WebhookError.ErrorNodeNameGenerator errorNameGenerator = mock(WebhookError.ErrorNodeNameGenerator.class);
-    private final WebhookError.WebhookErrorReaper errorReaper = new WebhookError.WebhookErrorReaper(zooKeeperUtils);
-
-    private final static String ZK_BASE_PATH = "/GroupError";
+    private final WebhookErrorPruner errorPruner = mock(WebhookErrorPruner.class);
+    private final WebhookErrorService errorService = mock(WebhookErrorService.class);
 
     @Test
-    public void testAddCleansUpOldestExcessiveErrors() {
+    public void testAdd() {
         String webhookName = "webhookName";
         String errorMessage = "someError";
-        String newErrorId = "error10";
 
-        when(errorNameGenerator.generateName())
-                .thenReturn(newErrorId);
-        setupErrorMocks(webhookName, 12, errorIndex -> Duration.ofMinutes(12 - errorIndex));
+        List<com.flightstats.hub.webhook.error.WebhookError> webhookErrors = setupErrorMocks(webhookName, 12);
+        List<com.flightstats.hub.webhook.error.WebhookError> errorsToDelete = webhookErrors.subList(0, 1);
+        when(errorPruner.pruneErrors(webhookName, webhookErrors)).thenReturn(errorsToDelete);
 
-        WebhookError webhookError = new WebhookError(zooKeeperUtils, channelService, errorNameGenerator, errorReaper);
+        WebhookError webhookError = new WebhookError(errorService, errorPruner, channelService);
 
         webhookError.add(webhookName, errorMessage);
-        verify(zooKeeperUtils).createData(errorMessage.getBytes(), ZK_BASE_PATH, webhookName, newErrorId);
-        verify(zooKeeperUtils, times(2)).deletePathInBackground(anyString(), anyString(), anyString());
-        verify(zooKeeperUtils).deletePathInBackground(ZK_BASE_PATH, webhookName, "error0");
-        verify(zooKeeperUtils).deletePathInBackground(ZK_BASE_PATH, webhookName, "error1");
+        verify(errorService).add(webhookName, errorMessage);
+        verify(errorPruner).pruneErrors(webhookName, webhookErrors);
     }
 
     @Test
-    public void testAddCleansUpErrorsOlderThanADay() {
+    public void testGet() {
         String webhookName = "webhookName";
-        String errorMessage = "someError";
-        String newErrorId = "error1";
 
-        when(errorNameGenerator.generateName())
-                .thenReturn(newErrorId);
-        setupErrorMocks(webhookName, 2, errorIndex -> Duration.ofDays(1 - errorIndex).plusMinutes(1));
+        List<com.flightstats.hub.webhook.error.WebhookError> webhookErrors = setupErrorMocks(webhookName, 6);
+        List<com.flightstats.hub.webhook.error.WebhookError> errorsToDelete = newArrayList(webhookErrors.get(1), webhookErrors.get(3), webhookErrors.get(5));
+        when(errorPruner.pruneErrors(webhookName, webhookErrors)).thenReturn(errorsToDelete);
 
-        WebhookError webhookError = new WebhookError(zooKeeperUtils, channelService, errorNameGenerator, errorReaper);
-
-        webhookError.add(webhookName, errorMessage);
-        verify(zooKeeperUtils).createData(errorMessage.getBytes(), ZK_BASE_PATH, webhookName, newErrorId);
-        verify(zooKeeperUtils, times(1)).deletePathInBackground(anyString(), anyString(), anyString());
-        verify(zooKeeperUtils).deletePathInBackground(ZK_BASE_PATH, webhookName, "error0");
-    }
-
-    @Test
-    public void testGetClearsExcessiveAndOldErrorsBeforeReturning() {
-        String webhookName = "webhookName";
-        setupErrorMocks(webhookName, 6, errorIndex -> Duration.ofDays(errorIndex % 2).plusMinutes(1));
-
-        WebhookError webhookError = new WebhookError(zooKeeperUtils, channelService, errorNameGenerator, errorReaper);
+        WebhookError webhookError = new WebhookError(errorService, errorPruner, channelService);
 
         List<String> errors = webhookError.get(webhookName);
 
         assertEquals(newArrayList("0 message", "2 message", "4 message"), errors);
-
-        verify(zooKeeperUtils, times(3)).deletePathInBackground(anyString(), anyString(), anyString());
-        verify(zooKeeperUtils).deletePathInBackground(ZK_BASE_PATH, webhookName, "error1");
-        verify(zooKeeperUtils).deletePathInBackground(ZK_BASE_PATH, webhookName, "error3");
-        verify(zooKeeperUtils).deletePathInBackground(ZK_BASE_PATH, webhookName, "error5");
     }
 
-    private void setupErrorMocks(String webhookName, int numberOfErrors, Function<Integer, Duration> createdAtOffsetCalculator) {
-        List<String> errors = IntStream.range(0, numberOfErrors).mapToObj(String::valueOf).map(number ->  "error" + number).collect(toList());
-        when(zooKeeperUtils.getChildren(ZK_BASE_PATH, webhookName)).thenReturn(errors);
-        IntStream.range(0, numberOfErrors).forEach(error ->
-                when(zooKeeperUtils.getDataWithStat(ZK_BASE_PATH, webhookName, errors.get(error)))
-                        .thenReturn(buildData(error + " message", TimeUtil.now().minus(createdAtOffsetCalculator.apply(error).toMillis()).getMillis())));
-    }
-
-    private Optional<SafeZooKeeperUtils.DataWithStat> buildData(String errorMessage, long ctime) {
-        Stat stat = new Stat();
-        stat.setCtime(ctime);
-        return Optional.of(SafeZooKeeperUtils.DataWithStat.builder()
-                .data(errorMessage)
-                .stat(stat)
-                .build());
+    private List<com.flightstats.hub.webhook.error.WebhookError> setupErrorMocks(String webhookName, int numberOfErrors) {
+        List<com.flightstats.hub.webhook.error.WebhookError> webhookErrors = IntStream.range(0, numberOfErrors)
+                .mapToObj(number -> com.flightstats.hub.webhook.error.WebhookError.builder()
+                        .name("error" + number)
+                        .data(number + " message")
+                        .build())
+                .collect(toList());
+        when(errorService.getErrors(webhookName)).thenReturn(webhookErrors);
+        return webhookErrors;
     }
 }

--- a/src/test/java/com/flightstats/hub/webhook/WebhookErrorUnitTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/WebhookErrorUnitTest.java
@@ -1,0 +1,102 @@
+package com.flightstats.hub.webhook;
+
+import com.flightstats.hub.dao.ChannelService;
+import com.flightstats.hub.util.TimeUtil;
+import com.flightstats.hub.util.SafeZooKeeperUtils;
+import org.apache.zookeeper.data.Stat;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class WebhookErrorUnitTest {
+    private final SafeZooKeeperUtils zooKeeperUtils = mock(SafeZooKeeperUtils.class);
+    private final ChannelService channelService = mock(ChannelService.class);
+    private final WebhookError.ErrorNodeNameGenerator errorNameGenerator = mock(WebhookError.ErrorNodeNameGenerator.class);
+    private final WebhookError.WebhookErrorReaper errorReaper = new WebhookError.WebhookErrorReaper(zooKeeperUtils);
+
+    private final static String ZK_BASE_PATH = "/GroupError";
+
+    @Test
+    public void testAddCleansUpOldestExcessiveErrors() {
+        String webhookName = "webhookName";
+        String errorMessage = "someError";
+        String newErrorId = "error10";
+
+        when(errorNameGenerator.generateName())
+                .thenReturn(newErrorId);
+        setupErrorMocks(webhookName, 12, errorIndex -> Duration.ofMinutes(12 - errorIndex));
+
+        WebhookError webhookError = new WebhookError(zooKeeperUtils, channelService, errorNameGenerator, errorReaper);
+
+        webhookError.add(webhookName, errorMessage);
+        verify(zooKeeperUtils).createData(errorMessage.getBytes(), ZK_BASE_PATH, webhookName, newErrorId);
+        verify(zooKeeperUtils, times(2)).deletePathInBackground(anyString(), anyString(), anyString());
+        verify(zooKeeperUtils).deletePathInBackground(ZK_BASE_PATH, webhookName, "error0");
+        verify(zooKeeperUtils).deletePathInBackground(ZK_BASE_PATH, webhookName, "error1");
+    }
+
+    @Test
+    public void testAddCleansUpErrorsOlderThanADay() {
+        String webhookName = "webhookName";
+        String errorMessage = "someError";
+        String newErrorId = "error1";
+
+        when(errorNameGenerator.generateName())
+                .thenReturn(newErrorId);
+        setupErrorMocks(webhookName, 2, errorIndex -> Duration.ofDays(1 - errorIndex).plusMinutes(1));
+
+        WebhookError webhookError = new WebhookError(zooKeeperUtils, channelService, errorNameGenerator, errorReaper);
+
+        webhookError.add(webhookName, errorMessage);
+        verify(zooKeeperUtils).createData(errorMessage.getBytes(), ZK_BASE_PATH, webhookName, newErrorId);
+        verify(zooKeeperUtils, times(1)).deletePathInBackground(anyString(), anyString(), anyString());
+        verify(zooKeeperUtils).deletePathInBackground(ZK_BASE_PATH, webhookName, "error0");
+    }
+
+    @Test
+    public void testGetClearsExcessiveAndOldErrorsBeforeReturning() {
+        String webhookName = "webhookName";
+        setupErrorMocks(webhookName, 6, errorIndex -> Duration.ofDays(errorIndex % 2).plusMinutes(1));
+
+        WebhookError webhookError = new WebhookError(zooKeeperUtils, channelService, errorNameGenerator, errorReaper);
+
+        List<String> errors = webhookError.get(webhookName);
+
+        assertEquals(newArrayList("0 message", "2 message", "4 message"), errors);
+
+        verify(zooKeeperUtils, times(3)).deletePathInBackground(anyString(), anyString(), anyString());
+        verify(zooKeeperUtils).deletePathInBackground(ZK_BASE_PATH, webhookName, "error1");
+        verify(zooKeeperUtils).deletePathInBackground(ZK_BASE_PATH, webhookName, "error3");
+        verify(zooKeeperUtils).deletePathInBackground(ZK_BASE_PATH, webhookName, "error5");
+    }
+
+    private void setupErrorMocks(String webhookName, int numberOfErrors, Function<Integer, Duration> createdAtOffsetCalculator) {
+        List<String> errors = IntStream.range(0, numberOfErrors).mapToObj(String::valueOf).map(number ->  "error" + number).collect(toList());
+        when(zooKeeperUtils.getChildren(ZK_BASE_PATH, webhookName)).thenReturn(errors);
+        IntStream.range(0, numberOfErrors).forEach(error ->
+                when(zooKeeperUtils.getDataWithStat(ZK_BASE_PATH, webhookName, errors.get(error)))
+                        .thenReturn(buildData(error + " message", TimeUtil.now().minus(createdAtOffsetCalculator.apply(error).toMillis()).getMillis())));
+    }
+
+    private Optional<SafeZooKeeperUtils.DataWithStat> buildData(String errorMessage, long ctime) {
+        Stat stat = new Stat();
+        stat.setCtime(ctime);
+        return Optional.of(SafeZooKeeperUtils.DataWithStat.builder()
+                .data(errorMessage)
+                .stat(stat)
+                .build());
+    }
+}

--- a/src/test/java/com/flightstats/hub/webhook/WebhookStateReaperTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/WebhookStateReaperTest.java
@@ -1,0 +1,153 @@
+package com.flightstats.hub.webhook;
+
+import com.flightstats.hub.cluster.LastContentPath;
+import com.flightstats.hub.cluster.ZooKeeperState;
+import com.flightstats.hub.dao.ChannelService;
+import com.flightstats.hub.model.ContentKey;
+import com.flightstats.hub.test.Integration;
+import com.flightstats.hub.util.SafeZooKeeperUtils;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.zookeeper.KeeperException;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class WebhookStateReaperTest {
+    private static CuratorFramework curator;
+    private LastContentPath lastContentPath;
+    private WebhookContentPathSet webhookInProcess;
+    private WebhookError webhookError;
+
+    private static final String webhookName = "onTheHook";
+    private static final DateTime start = new DateTime(2014, 12, 3, 20, 45, DateTimeZone.UTC);
+    private static final ContentKey key = new ContentKey(start, "B");
+
+    @BeforeClass
+    public static void setupCurator() throws Exception {
+        curator = Integration.startZooKeeper();
+    }
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() {
+        ChannelService channelService = mock(ChannelService.class);
+        SafeZooKeeperUtils zooKeeperUtils = new SafeZooKeeperUtils(curator);
+
+        lastContentPath = new LastContentPath(curator);
+        webhookError = new WebhookError(curator, channelService);
+        webhookInProcess = new WebhookContentPathSet(zooKeeperUtils);
+    }
+
+    @Test
+    public void testCleansUpZookeeperNodesRelatedToState() throws Exception {
+        // GIVEN
+        addLastCompleted(webhookName);
+        addWebhookInProcess(webhookName);
+        addError(webhookName);
+
+        // WHEN
+        WebhookStateReaper reaper = new WebhookStateReaper(lastContentPath, webhookInProcess, webhookError);
+        reaper.delete(webhookName);
+
+        // THEN
+        assertLastCompletedDeleted(webhookName);
+        assertErrorDeleted(webhookName);
+        assertWebhookInProcessDeleted(webhookName);
+    }
+
+    @Test
+    public void testCleansUpZookeeperNodesRelatedToState_whenNoWebhookErrors() throws Exception {
+        // GIVEN
+        addLastCompleted(webhookName);
+        addWebhookInProcess(webhookName);
+
+        // WHEN
+        WebhookStateReaper reaper = new WebhookStateReaper(lastContentPath, webhookInProcess, webhookError);
+        reaper.delete(webhookName);
+
+        // THEN
+        assertLastCompletedDeleted(webhookName);
+        assertErrorDeleted(webhookName);
+        assertWebhookInProcessDeleted(webhookName);
+    }
+
+    @Test
+    public void testCleansUpZookeeperNodesRelatedToState_whenNoWebhookInProcess() throws Exception {
+        // GIVEN
+        addLastCompleted(webhookName);
+        addError(webhookName);
+
+        // WHEN
+        WebhookStateReaper reaper = new WebhookStateReaper(lastContentPath, webhookInProcess, webhookError);
+        reaper.delete(webhookName);
+
+        // THEN
+        assertLastCompletedDeleted(webhookName);
+        assertErrorDeleted(webhookName);
+        assertWebhookInProcessDeleted(webhookName);
+    }
+
+    @Test
+    public void testCleansUpZookeeperNodesRelatedToState_whenNoContentWasAdded() throws Exception {
+        // GIVEN
+        addWebhookInProcess(webhookName);
+        addError(webhookName);
+
+        // WHEN
+        WebhookStateReaper reaper = new WebhookStateReaper(lastContentPath, webhookInProcess, webhookError);
+        reaper.delete(webhookName);
+
+        // THEN
+        assertLastCompletedDeleted(webhookName);
+        assertErrorDeleted(webhookName);
+        assertWebhookInProcessDeleted(webhookName);
+    }
+
+    private void addLastCompleted(String webhook) throws Exception {
+        lastContentPath.initialize(webhook, key, WebhookLeader.WEBHOOK_LAST_COMPLETED);
+        assertLastCompletedExists(webhook);
+    }
+
+    private void addWebhookInProcess(String webhook) {
+        webhookInProcess.add(webhook, key);
+        assertWebhookInProcessExists(webhook);
+    }
+
+    private void addError(String webhook) {
+        webhookError.add(webhook, "oops");
+        assertErrorExists(webhook);
+    }
+
+    private void assertLastCompletedExists(String webhook) throws Exception {
+        assertTrue(curator.getData().forPath(WebhookLeader.WEBHOOK_LAST_COMPLETED + webhook).length > 0);
+    }
+
+    private void assertWebhookInProcessExists(String webhook) {
+        assertEquals(1, webhookInProcess.getSet(webhook, key).size());
+    }
+
+    private void assertErrorExists(String webhook) {
+        assertEquals(1, webhookError.get(webhook).size());
+    }
+
+    private void assertLastCompletedDeleted(String webhook) {
+        assertThrows(KeeperException.NoNodeException.class,
+                () -> curator.getData().forPath(WebhookLeader.WEBHOOK_LAST_COMPLETED + webhook));
+    }
+
+    private void assertErrorDeleted(String webhook) {
+        assertTrue(webhookError.get(webhook).isEmpty());
+    }
+
+    private void assertWebhookInProcessDeleted(String webhook) {
+        assertTrue(webhookInProcess.getSet(webhook, key).isEmpty());
+    }
+}

--- a/src/test/java/com/flightstats/hub/webhook/WebhookStateReaperTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/WebhookStateReaperTest.java
@@ -1,11 +1,12 @@
 package com.flightstats.hub.webhook;
 
 import com.flightstats.hub.cluster.LastContentPath;
-import com.flightstats.hub.cluster.ZooKeeperState;
 import com.flightstats.hub.dao.ChannelService;
 import com.flightstats.hub.model.ContentKey;
 import com.flightstats.hub.test.Integration;
 import com.flightstats.hub.util.SafeZooKeeperUtils;
+import com.flightstats.hub.webhook.error.WebhookErrorPruner;
+import com.flightstats.hub.webhook.error.WebhookErrorService;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.zookeeper.KeeperException;
 import org.joda.time.DateTime;
@@ -40,9 +41,11 @@ public class WebhookStateReaperTest {
     public void setup() {
         ChannelService channelService = mock(ChannelService.class);
         SafeZooKeeperUtils zooKeeperUtils = new SafeZooKeeperUtils(curator);
+        WebhookErrorService webhookErrorService = new WebhookErrorService(zooKeeperUtils);
+        WebhookErrorPruner webhookErrorPruner = new WebhookErrorPruner(webhookErrorService);
 
         lastContentPath = new LastContentPath(curator);
-        webhookError = new WebhookError(curator, channelService);
+        webhookError = new WebhookError(webhookErrorService, webhookErrorPruner, channelService);
         webhookInProcess = new WebhookContentPathSet(zooKeeperUtils);
     }
 

--- a/src/test/java/com/flightstats/hub/webhook/error/WebhookErrorPrunerTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/error/WebhookErrorPrunerTest.java
@@ -1,0 +1,68 @@
+package com.flightstats.hub.webhook.error;
+
+import com.flightstats.hub.util.TimeUtil;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class WebhookErrorPrunerTest {
+    private final WebhookErrorService errorService = mock(WebhookErrorService.class);
+
+    @Test
+    public void testAddCleansUpOldestExcessiveErrors() {
+        String webhookName = "webhookName";
+
+        List<WebhookError> webhookErrors = setupErrorMocks(webhookName, 12, errorIndex -> Duration.ofMinutes(12 - errorIndex));
+
+        WebhookErrorPruner webhookErrorPruner = new WebhookErrorPruner(errorService);
+
+        List<WebhookError> prunedErrors = webhookErrorPruner.pruneErrors(webhookName, webhookErrors);
+
+        assertEquals(newArrayList("error0", "error1"), prunedErrors.stream().map(WebhookError::getName).collect(toList()));
+
+        verify(errorService, times(2)).delete(anyString(), anyString());
+        verify(errorService).delete(webhookName, "error0");
+        verify(errorService).delete(webhookName, "error1");
+    }
+
+    @Test
+    public void testAddCleansUpErrorsOlderThanADay() {
+        String webhookName = "webhookName";
+
+        List<WebhookError> webhookErrors = setupErrorMocks(webhookName, 2, errorIndex -> Duration.ofDays(1 - errorIndex).plusMinutes(1));
+
+        WebhookErrorPruner webhookErrorPruner = new WebhookErrorPruner(errorService);
+
+        List<WebhookError> prunedErrors = webhookErrorPruner.pruneErrors(webhookName, webhookErrors);
+
+        assertEquals(newArrayList("error0"), prunedErrors.stream().map(WebhookError::getName).collect(toList()));
+
+        verify(errorService, times(1)).delete(anyString(), anyString());
+        verify(errorService).delete(webhookName, "error0");
+    }
+
+    private List<WebhookError> setupErrorMocks(String webhookName, int numberOfErrors, Function<Integer, Duration> createdAtOffsetCalculator) {
+        List<WebhookError> webhookErrors = IntStream.range(0, numberOfErrors)
+                .mapToObj(number -> com.flightstats.hub.webhook.error.WebhookError.builder()
+                        .name("error" + number)
+                        .data(number + " message")
+                        .creationTime(TimeUtil.now().minus(createdAtOffsetCalculator.apply(number).toMillis()))
+                        .build())
+                .collect(toList());
+        when(errorService.getErrors(webhookName)).thenReturn(webhookErrors);
+        return webhookErrors;
+    }
+
+}

--- a/src/test/java/com/flightstats/hub/webhook/error/WebhookErrorServiceTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/error/WebhookErrorServiceTest.java
@@ -1,0 +1,98 @@
+package com.flightstats.hub.webhook.error;
+
+import com.flightstats.hub.util.SafeZooKeeperUtils;
+import com.flightstats.hub.util.TimeUtil;
+import org.apache.zookeeper.data.Stat;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Sets.newHashSet;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class WebhookErrorServiceTest {
+    private final SafeZooKeeperUtils zooKeeperUtils = mock(SafeZooKeeperUtils.class);
+    private final WebhookErrorService.ErrorNodeNameGenerator errorNameGenerator = mock(WebhookErrorService.ErrorNodeNameGenerator.class);
+
+    private final static String ZK_BASE_PATH = "/GroupError";
+    public static final String WEBHOOK_NAME = "webhookName";
+
+    @Test
+    public void testAdd() {
+        String errorMessage = "someError";
+        String newErrorId = "error10";
+
+        when(errorNameGenerator.generateName())
+                .thenReturn(newErrorId);
+
+        WebhookErrorService errorService = new WebhookErrorService(zooKeeperUtils, errorNameGenerator);
+        errorService.add(WEBHOOK_NAME, errorMessage);
+        verify(zooKeeperUtils).createData(errorMessage.getBytes(), ZK_BASE_PATH, WEBHOOK_NAME, newErrorId);
+    }
+
+    @Test
+    public void testDeleteWebhook() {
+        WebhookErrorService errorService = new WebhookErrorService(zooKeeperUtils, errorNameGenerator);
+        errorService.deleteWebhook(WEBHOOK_NAME);
+        verify(zooKeeperUtils).deletePathAndChildren(ZK_BASE_PATH, WEBHOOK_NAME);
+    }
+
+    @Test
+    public void testDelete() {
+        String errorId = "error10";
+
+        WebhookErrorService errorService = new WebhookErrorService(zooKeeperUtils, errorNameGenerator);
+        errorService.delete(WEBHOOK_NAME, errorId);
+        verify(zooKeeperUtils).deletePathInBackground(ZK_BASE_PATH, WEBHOOK_NAME, errorId);
+    }
+
+    @Test
+    public void testGetWebhooks() {
+        List<String> webhooks = newArrayList("1", "2", "3");
+        when(zooKeeperUtils.getChildren(ZK_BASE_PATH))
+                .thenReturn(webhooks);
+
+        WebhookErrorService errorService = new WebhookErrorService(zooKeeperUtils, errorNameGenerator);
+
+        assertEquals(newHashSet(webhooks), errorService.getWebhooks());
+    }
+
+    @Test
+    public void testGetErrors() {
+        List<String> errors = newArrayList("1", "2", "3");
+        when(zooKeeperUtils.getChildren(ZK_BASE_PATH, WEBHOOK_NAME))
+                .thenReturn(errors);
+
+        DateTime createdStart = TimeUtil.now();
+        when(zooKeeperUtils.getDataWithStat(ZK_BASE_PATH, WEBHOOK_NAME, "1"))
+                .thenReturn(buildData("error1", createdStart.plusMinutes(1)));
+        when(zooKeeperUtils.getDataWithStat(ZK_BASE_PATH, WEBHOOK_NAME, "2"))
+                .thenReturn(Optional.empty());
+        when(zooKeeperUtils.getDataWithStat(ZK_BASE_PATH, WEBHOOK_NAME, "3"))
+                .thenReturn(buildData("error3", createdStart.plusMinutes(3)));
+
+        WebhookErrorService errorService = new WebhookErrorService(zooKeeperUtils, errorNameGenerator);
+
+        List<WebhookError> expectedErrors = newArrayList(
+                WebhookError.builder().name("1").data("error1").creationTime(createdStart.plusMinutes(1).withZone(DateTimeZone.getDefault())).build(),
+                WebhookError.builder().name("3").data("error3").creationTime(createdStart.plusMinutes(3).withZone(DateTimeZone.getDefault())).build()
+        );
+        assertEquals(expectedErrors, errorService.getErrors(WEBHOOK_NAME));
+    }
+
+    private Optional<SafeZooKeeperUtils.DataWithStat> buildData(String errorMessage, DateTime ctime) {
+        Stat stat = new Stat();
+        stat.setCtime(ctime.getMillis());
+        return Optional.of(SafeZooKeeperUtils.DataWithStat.builder()
+                .data(errorMessage)
+                .stat(stat)
+                .build());
+    }
+}


### PR DESCRIPTION
We delete webhooks in a couple places and have some ZK state that we don't currently clean up consistently, so this fixes that. This doesn't affect prod much, since we don't delete webhooks that often, but dev had a pretty massive number of orphaned webhook state.

Other than the first commit bug fix, there's some pretty serious refactoring to `WebhookError`, which might not have been strictly necessary, but the single test it had bugged me and I wanted to use the ZK utils class there, too.

This is currently based on the PR y'all just reviewed. When that's merged, I'll change it to be based on master. Planning to merge that one after we deploy tomorrow.