### PR TITLE
Update webhook LAST_COMPLETED ZK node with the minute before the first failed s3 verifier update

### DIFF
--- a/src/test/java/com/flightstats/hub/dao/aws/S3VerifierUnitTest.java
+++ b/src/test/java/com/flightstats/hub/dao/aws/S3VerifierUnitTest.java
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.when;
 public class S3VerifierUnitTest {
 
     @Test
-    public void testZKNotUpdatedOnFailure() {
+    public void testZKDoesNotUpdateOnAbsoluteFailure() {
         LastContentPath lastContentPath = mock(LastContentPath.class);
         ChannelService channelService = mock(ChannelService.class);
         ContentDao spokeWriteContentDao = mock(ContentDao.class);
@@ -55,6 +55,81 @@ public class S3VerifierUnitTest {
         s3Verifier.verifyChannel(verifierRange);
 
         verifyZeroInteractions(lastContentPath);
+    }
+
+    @Test
+    public void testZKUpdatesWithPartialCompletionIfVerifierFailsPartwayThroughAndLastSuccessfulWasADifferentMinute() {
+        LastContentPath lastContentPath = mock(LastContentPath.class);
+        ChannelService channelService = mock(ChannelService.class);
+        ContentDao spokeWriteContentDao = mock(ContentDao.class);
+        ContentDao s3SingleContentDao = mock(ContentDao.class);
+        S3WriteQueue s3WriteQueue = mock(S3WriteQueue.class);
+        Client httpClient = mock(Client.class);
+        ZooKeeperState zooKeeperState = mock(ZooKeeperState.class);
+        CuratorFramework curator = mock(CuratorFramework.class);
+        MetricsService metricsService = mock(MetricsService.class);
+        S3Verifier s3Verifier = spy(new S3Verifier(lastContentPath, channelService, spokeWriteContentDao, s3SingleContentDao, s3WriteQueue, httpClient, zooKeeperState, curator, metricsService));
+
+        ChannelContentKey key = ChannelContentKey.fromResourcePath("http://hub/channel/foo/1999/12/31/23/58/59/999/bar");
+        ChannelContentKey secondKey = ChannelContentKey.fromResourcePath("http://hub/channel/foo/1999/12/31/23/59/59/999/bar");
+        VerifierRange verifierRange = VerifierRange.builder()
+                .channelConfig(ChannelConfig.builder().name("foo").build())
+                .startPath(new MinutePath(DateTime.parse("1999-12-31T23:57:59.999Z")))
+                .endPath(new MinutePath(DateTime.parse("2000-01-01T00:00:00.000Z")))
+                .build();
+        SortedSet<ContentKey> missingKeys = new TreeSet<>();
+        missingKeys.add(secondKey.getContentKey());
+        missingKeys.add(key.getContentKey());
+
+        when(s3Verifier.getMissing(verifierRange.getStartPath(), verifierRange.getEndPath(), "foo", s3SingleContentDao, new TreeSet<>())).thenReturn(missingKeys);
+        when(s3WriteQueue.add(key)).thenReturn(true);
+        when(s3WriteQueue.add(secondKey)).thenReturn(false);
+
+        s3Verifier.verifyChannel(verifierRange);
+
+        MinutePath firstKeyMinute = new MinutePath(key.getContentKey().getTime());
+        verify(lastContentPath, times(1)).updateIncrease(firstKeyMinute, verifierRange.getChannelConfig().getDisplayName(), LAST_SINGLE_VERIFIED);
+    }
+
+    @Test
+    public void testZKUpdatesWithPartialCompletionIfVerifierFailsPartwayThroughAMinute() {
+        LastContentPath lastContentPath = mock(LastContentPath.class);
+        ChannelService channelService = mock(ChannelService.class);
+        ContentDao spokeWriteContentDao = mock(ContentDao.class);
+        ContentDao s3SingleContentDao = mock(ContentDao.class);
+        S3WriteQueue s3WriteQueue = mock(S3WriteQueue.class);
+        Client httpClient = mock(Client.class);
+        ZooKeeperState zooKeeperState = mock(ZooKeeperState.class);
+        CuratorFramework curator = mock(CuratorFramework.class);
+        MetricsService metricsService = mock(MetricsService.class);
+        S3Verifier s3Verifier = spy(new S3Verifier(lastContentPath, channelService, spokeWriteContentDao, s3SingleContentDao, s3WriteQueue, httpClient, zooKeeperState, curator, metricsService));
+
+        ChannelContentKey key = ChannelContentKey.fromResourcePath("http://hub/channel/foo/1999/12/31/23/57/59/999/bar");
+        ChannelContentKey secondKey = ChannelContentKey.fromResourcePath("http://hub/channel/foo/1999/12/31/23/59/59/999/bar");
+        ChannelContentKey thirdKey = ChannelContentKey.fromResourcePath("http://hub/channel/foo/1999/12/31/23/59/59/999/baz");
+        VerifierRange verifierRange = VerifierRange.builder()
+                .channelConfig(ChannelConfig.builder().name("foo").build())
+                .startPath(new MinutePath(DateTime.parse("1999-12-31T23:56:59.999Z")))
+                .endPath(new MinutePath(DateTime.parse("2000-01-01T00:00:00.000Z")))
+                .build();
+        SortedSet<ContentKey> missingKeys = new TreeSet<>();
+        missingKeys.add(thirdKey.getContentKey());
+        missingKeys.add(key.getContentKey());
+        missingKeys.add(secondKey.getContentKey());
+
+        when(s3Verifier.getMissing(verifierRange.getStartPath(), verifierRange.getEndPath(), "foo", s3SingleContentDao, new TreeSet<>())).thenReturn(missingKeys);
+        when(s3WriteQueue.add(key)).thenReturn(true);
+        when(s3WriteQueue.add(secondKey)).thenReturn(true);
+        when(s3WriteQueue.add(thirdKey)).thenReturn(false);
+
+        s3Verifier.verifyChannel(verifierRange);
+
+        verify(s3WriteQueue, times(1)).add(key);
+        verify(s3WriteQueue, times(1)).add(secondKey);
+        verify(s3WriteQueue, times(1)).add(thirdKey);
+
+        MinutePath minuteBeforeFailure = new MinutePath(DateTime.parse("1999-12-31T23:58:00.000Z"));
+        verify(lastContentPath, times(1)).updateIncrease(minuteBeforeFailure, verifierRange.getChannelConfig().getDisplayName(), LAST_SINGLE_VERIFIED);
     }
 
     @Test


### PR DESCRIPTION
I resisted the urge to `stream`ify this logic, so (yay) I introduced more mutable state!

This will assume we update to the end range of the verifier run, but if it encounters an error, it'll set last completed to the minute before the failure. If that means that it got past the first minute, we'll update the ZK node. 

~Question: should we update it if the failure happens in the first minute after the start path (i.e we start the range at 12:00 and have a failure somewhere in the items at 12:01, should we update last completed to 12:00?)~ (LAST_COMPLETED minute is exclusive for spoke, so no need to do this)