### PR TITLE
Stop periodically looking for empty webhook leader zk nodes, just delete them when we delete webhooks

### DIFF
--- a/src/main/java/com/flightstats/hub/webhook/ActiveWebhooks.java
+++ b/src/main/java/com/flightstats/hub/webhook/ActiveWebhooks.java
@@ -1,14 +1,11 @@
 package com.flightstats.hub.webhook;
 
 import com.flightstats.hub.app.HubHost;
-import com.google.common.util.concurrent.AbstractScheduledService;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
-import static com.flightstats.hub.app.HubServices.register;
 import static java.util.stream.Collectors.toSet;
 
 @Singleton

--- a/src/main/java/com/flightstats/hub/webhook/ActiveWebhooks.java
+++ b/src/main/java/com/flightstats/hub/webhook/ActiveWebhooks.java
@@ -14,14 +14,12 @@ import static java.util.stream.Collectors.toSet;
 @Singleton
 public class ActiveWebhooks {
     private final WebhookLeaderLocks webhookLeaderLocks;
-    private final ActiveWebhookSweeper activeWebhookSweeper;
 
     @Inject
     public ActiveWebhooks(WebhookLeaderLocks webhookLeaderLocks, ActiveWebhookSweeper activeWebhookSweeper) {
         this.webhookLeaderLocks = webhookLeaderLocks;
-        this.activeWebhookSweeper = activeWebhookSweeper;
 
-        register(new WebhookLeaderCleanupService());
+        activeWebhookSweeper.cleanupEmpty();
     }
 
     public boolean isActiveWebhook(String webhookName) {
@@ -32,17 +30,5 @@ public class ActiveWebhooks {
         return webhookLeaderLocks.getServerLeases(name).stream()
                 .map(server -> server + ":" + HubHost.getLocalPort())
                 .collect(toSet());
-    }
-
-    private class WebhookLeaderCleanupService extends AbstractScheduledService {
-        @Override
-        protected void runOneIteration() throws Exception {
-            activeWebhookSweeper.cleanupEmpty();
-        }
-
-        @Override
-        protected Scheduler scheduler() {
-            return Scheduler.newFixedRateSchedule(2, 5, TimeUnit.MINUTES);
-        }
     }
 }

--- a/src/main/java/com/flightstats/hub/webhook/WebhookErrorService.java
+++ b/src/main/java/com/flightstats/hub/webhook/WebhookErrorService.java
@@ -10,8 +10,7 @@ import com.flightstats.hub.webhook.error.WebhookErrorPruner;
 import com.flightstats.hub.webhook.error.WebhookErrorRepository;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.Comparator;
 import java.util.List;
@@ -31,9 +30,8 @@ import static java.util.stream.Collectors.toList;
  */
 
 @Singleton
+@Slf4j
 class WebhookErrorService {
-    private final static Logger logger = LoggerFactory.getLogger(WebhookErrorService.class);
-
     private final WebhookErrorRepository webhookErrorRepository;
     private final ChannelService channelService;
     private final WebhookErrorPruner webhookErrorPruner;
@@ -51,7 +49,7 @@ class WebhookErrorService {
     }
 
     public void delete(String webhook) {
-        logger.info("deleting webhook errors for " + webhook);
+        log.info("deleting webhook errors for " + webhook);
         webhookErrorRepository.deleteWebhook(webhook);
     }
 
@@ -78,7 +76,7 @@ class WebhookErrorService {
 
         List<String> errors = lookup(attempt.getWebhook().getName());
         if (errors.size() < 1) {
-            logger.debug("no errors found for", attempt.getWebhook().getName());
+            log.debug("no errors found for", attempt.getWebhook().getName());
             return;
         }
 
@@ -93,7 +91,7 @@ class WebhookErrorService {
         try {
             channelService.insert(getChannelName(attempt.getWebhook().getErrorChannelUrl()), content);
         } catch (Exception e) {
-            logger.warn("unable to publish errors for " + attempt.getWebhook().getName(), e);
+            log.warn("unable to publish errors for " + attempt.getWebhook().getName(), e);
         }
     }
 

--- a/src/main/java/com/flightstats/hub/webhook/WebhookManager.java
+++ b/src/main/java/com/flightstats/hub/webhook/WebhookManager.java
@@ -13,9 +13,8 @@ import com.google.common.util.concurrent.AbstractScheduledService;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.framework.api.CuratorEvent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -23,10 +22,8 @@ import java.util.concurrent.TimeUnit;
 import static com.flightstats.hub.app.HubServices.register;
 
 @Singleton
+@Slf4j
 public class WebhookManager {
-
-    private final static Logger logger = LoggerFactory.getLogger(WebhookManager.class);
-
     private static final String WATCHER_PATH = "/groupCallback/watcher";
 
     @Inject
@@ -74,7 +71,7 @@ public class WebhookManager {
     }
 
     private void start() {
-        logger.info("starting");
+        log.info("starting");
         watchManager.register(new Watcher() {
             @Override
             public void callback(CuratorEvent event) {
@@ -112,10 +109,10 @@ public class WebhookManager {
         }
         String name = daoWebhook.getName();
         if (activeWebhooks.isActiveWebhook(name)) {
-            logger.debug("found existing v2 webhook {}", name);
+            log.debug("found existing v2 webhook {}", name);
             List<String> servers = new ArrayList<>(activeWebhooks.getServers(name));
             if (servers.size() >= 2) {
-                logger.warn("found multiple servers! {}", servers);
+                log.warn("found multiple servers! {}", servers);
                 Collections.shuffle(servers);
                 for (int i = 1; i < servers.size(); i++) {
                     webhookClient.remove(name, servers.get(i));
@@ -127,7 +124,7 @@ public class WebhookManager {
                 webhookClient.runOnOneServer(name, servers);
             }
         } else {
-            logger.debug("found new v2 webhook {}", name);
+            log.debug("found new v2 webhook {}", name);
             webhookClient.runOnServerWithFewestWebhooks(name);
         }
     }
@@ -148,7 +145,7 @@ public class WebhookManager {
             ArrayList<ContentPath> inFlight = new ArrayList<>(new TreeSet<>(webhookInProcess.getSet(webhook.getName(), WebhookStrategy.createContentPath(webhook))));
             statusBuilder.inFlight(inFlight);
         } catch (Exception e) {
-            logger.warn("unable to get status " + webhook.getName(), e);
+            log.warn("unable to get status " + webhook.getName(), e);
             statusBuilder.errors(Collections.emptyList());
             statusBuilder.inFlight(Collections.emptyList());
         }

--- a/src/main/java/com/flightstats/hub/webhook/WebhookStateReaper.java
+++ b/src/main/java/com/flightstats/hub/webhook/WebhookStateReaper.java
@@ -1,8 +1,7 @@
 package com.flightstats.hub.webhook;
 
 import com.flightstats.hub.cluster.LastContentPath;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -10,9 +9,8 @@ import javax.inject.Singleton;
 import static com.flightstats.hub.webhook.WebhookLeader.WEBHOOK_LAST_COMPLETED;
 
 @Singleton
+@Slf4j
 class WebhookStateReaper {
-    private final static Logger logger = LoggerFactory.getLogger(WebhookStateReaper.class);
-
     private final LastContentPath lastContentPath;
     private final WebhookContentPathSet webhookInProcess;
     private final WebhookErrorService webhookErrorService;
@@ -30,11 +28,11 @@ class WebhookStateReaper {
     }
 
     void delete(String webhook) {
-        logger.info("deleting " + webhook);
+        log.info("deleting " + webhook);
         webhookInProcess.delete(webhook);
         lastContentPath.delete(webhook, WEBHOOK_LAST_COMPLETED);
         webhookErrorService.delete(webhook);
         webhookLeaderLocks.deleteWebhookLeader(webhook);
-        logger.info("deleted " + webhook);
+        log.info("deleted " + webhook);
     }
 }

--- a/src/main/java/com/flightstats/hub/webhook/WebhookStateReaper.java
+++ b/src/main/java/com/flightstats/hub/webhook/WebhookStateReaper.java
@@ -16,14 +16,17 @@ class WebhookStateReaper {
     private final LastContentPath lastContentPath;
     private final WebhookContentPathSet webhookInProcess;
     private final WebhookErrorService webhookErrorService;
+    private final WebhookLeaderLocks webhookLeaderLocks;
 
     @Inject
     WebhookStateReaper(LastContentPath lastContentPath,
                        WebhookContentPathSet webhookInProcess,
-                       WebhookErrorService webhookErrorService) {
+                       WebhookErrorService webhookErrorService,
+                       WebhookLeaderLocks webhookLeaderLocks) {
         this.lastContentPath = lastContentPath;
         this.webhookInProcess = webhookInProcess;
         this.webhookErrorService = webhookErrorService;
+        this.webhookLeaderLocks = webhookLeaderLocks;
     }
 
     void delete(String webhook) {
@@ -31,6 +34,7 @@ class WebhookStateReaper {
         webhookInProcess.delete(webhook);
         lastContentPath.delete(webhook, WEBHOOK_LAST_COMPLETED);
         webhookErrorService.delete(webhook);
+        webhookLeaderLocks.deleteWebhookLeader(webhook);
         logger.info("deleted " + webhook);
     }
 }

--- a/src/main/java/com/flightstats/hub/webhook/error/WebhookErrorRepository.java
+++ b/src/main/java/com/flightstats/hub/webhook/error/WebhookErrorRepository.java
@@ -4,9 +4,8 @@ import com.flightstats.hub.util.SafeZooKeeperUtils;
 import com.flightstats.hub.util.StringUtils;
 import com.flightstats.hub.util.TimeUtil;
 import com.google.common.annotations.VisibleForTesting;
+import lombok.extern.slf4j.Slf4j;
 import org.joda.time.DateTime;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.util.HashSet;
@@ -16,8 +15,8 @@ import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
 
+@Slf4j
 public class WebhookErrorRepository {
-    private static final Logger logger = LoggerFactory.getLogger(WebhookErrorRepository.class);
     private static final String BASE_PATH = "/GroupError";
 
     private final SafeZooKeeperUtils zooKeeperUtils;
@@ -34,7 +33,7 @@ public class WebhookErrorRepository {
     }
 
     public void deleteWebhook(String webhook) {
-        logger.info("deleting webhook errors for " + webhook);
+        log.info("deleting webhook errors for " + webhook);
         zooKeeperUtils.deletePathAndChildren(BASE_PATH, webhook);
     }
 

--- a/src/test/java/com/flightstats/hub/webhook/ActiveWebhooksIntTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/ActiveWebhooksIntTest.java
@@ -1,0 +1,107 @@
+package com.flightstats.hub.webhook;
+
+import com.flightstats.hub.app.HubHost;
+import com.flightstats.hub.metrics.MetricsService;
+import com.flightstats.hub.test.Integration;
+import com.flightstats.hub.util.SafeZooKeeperUtils;
+import org.apache.curator.framework.CuratorFramework;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+
+import static com.google.common.collect.Sets.newHashSet;
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.testng.AssertJUnit.assertTrue;
+
+public class ActiveWebhooksIntTest {
+    private static final String WEBHOOK_LEADER_PATH = "/WebhookLeader";
+
+
+    private static final String WEBHOOK_WITH_LEASE = "webhook1";
+    private static final String WEBHOOK_WITH_A_FEW_LEASES = "webhook4";
+    private static final String WEBHOOK_WITH_LOCK = "webhook3";
+    private static final String EMPTY_WEBHOOK = "webhook2";
+
+    private static final String SERVER_IP1 = "10.2.1";
+    private static final String SERVER_IP2 = "10.2.2";
+
+    private static CuratorFramework curator;
+    private static SafeZooKeeperUtils zooKeeperUtils;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        curator = Integration.startZooKeeper();
+        zooKeeperUtils = new SafeZooKeeperUtils(curator);
+    }
+
+    @Before
+    public void createWebhookLeader() throws Exception {
+        curator.create().creatingParentsIfNeeded().forPath(WEBHOOK_LEADER_PATH);
+    }
+
+    @After
+    public void destroyWebhookLeaders() throws Exception {
+        curator.delete().deletingChildrenIfNeeded().forPath(WEBHOOK_LEADER_PATH);
+    }
+
+    @Test
+    public void testCleanupEmpty_keepsWebhooksWithLeasesAndLocksAndDiscardsOthers() throws Exception {
+        createWebhookLease(WEBHOOK_WITH_A_FEW_LEASES, "someLease", SERVER_IP1);
+        createWebhookLease(WEBHOOK_WITH_A_FEW_LEASES, "someLease2", SERVER_IP2);
+        createWebhookLease(WEBHOOK_WITH_A_FEW_LEASES, "someLease3", SERVER_IP2);
+
+        createWebhookLock(WEBHOOK_WITH_LEASE, "someLock", "");
+        createWebhookLease(WEBHOOK_WITH_LEASE, "someLease", SERVER_IP1);
+
+        createWebhookLock(WEBHOOK_WITH_LOCK, "aLock", "???");
+
+        createWebhook(EMPTY_WEBHOOK);
+
+        WebhookLeaderLocks webhookLeaderLocks = new WebhookLeaderLocks(zooKeeperUtils);
+        ActiveWebhookSweeper activeWebhookSweeper = new ActiveWebhookSweeper(webhookLeaderLocks, mock(MetricsService.class));
+        ActiveWebhooks activeWebhooks = new ActiveWebhooks(webhookLeaderLocks, activeWebhookSweeper);
+
+        List<String> webhooks = curator.getChildren().forPath(WEBHOOK_LEADER_PATH);
+        assertEquals(3, webhooks.size());
+        assertEquals(newHashSet(WEBHOOK_WITH_LOCK, WEBHOOK_WITH_A_FEW_LEASES, WEBHOOK_WITH_LEASE), newHashSet(webhooks));
+
+        assertTrue(activeWebhooks.isActiveWebhook(WEBHOOK_WITH_A_FEW_LEASES));
+        assertTrue(activeWebhooks.isActiveWebhook(WEBHOOK_WITH_LEASE));
+        assertTrue(activeWebhooks.isActiveWebhook(WEBHOOK_WITH_LOCK));
+
+        assertFalse(activeWebhooks.isActiveWebhook(EMPTY_WEBHOOK));
+    }
+
+    private static void createWebhook(String webhook) {
+        try {
+            curator.create().creatingParentsIfNeeded().forPath(format("%s/%s/locks", WEBHOOK_LEADER_PATH, webhook), "".getBytes());
+            curator.create().creatingParentsIfNeeded().forPath(format("%s/%s/leases", WEBHOOK_LEADER_PATH, webhook), "".getBytes());
+        } catch(Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    private static void createWebhookLock(String webhook, String lockName, String value) {
+        try {
+            curator.create().creatingParentsIfNeeded().forPath(format("%s/%s/locks/%s", WEBHOOK_LEADER_PATH, webhook, lockName), value.getBytes());
+        } catch(Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    private static void createWebhookLease(String webhook, String leaseName, String value) {
+        String leasePath = format("%s/%s/leases/%s", WEBHOOK_LEADER_PATH, webhook, leaseName);
+        try {
+            curator.create().creatingParentsIfNeeded().forPath(leasePath, value.getBytes());
+        } catch(Exception e) {
+            fail(e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
As part of the zookeeper cleanup, I created a job that would go through and find webhook leader nodes without locks and leases. This executed the same code that had originally been running whenever a node started up.

It turned out the code doesn't do what I thought it did. After reading the logs, it looks like due to the lifecycle of ZK webhook leader locks, sometimes an active webhook meets the requirements in the existing code and the node was getting deleted (without releasing leadership) and then recreated shortly afterwards, occasionally causing two nodes to think they were leaders.

So I reverted the periodic cleanup and the strange code will go back to only executing on startup (Commit 1). In commit 2, I solve the same problem in a (hopefully) safer way, by adding webhook leader ZK node deletion to part of the process of deleting webhook state when we delete webhooks...

I think this fixes the main issue that was causing the frequent duplicate webhook item issue that was introduced earlier. The work I have in another branch around curator locks and putting a lock around the WebhookLeader node will (probably) sew up the other duplicate issues that had been seen previously.