### PR TITLE
PDXDDT-683 Replace TestNG library with Junit library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,7 @@ dependencies {
     testCompile 'com.sparkjava:spark-core:2.7.1'
     testCompile 'junit:junit:4.+'
     testCompile "org.mockito:mockito-all:1.+"
-    testCompile 'org.testng:testng:6.+'
+
 }
 
 

--- a/src/test/java/com/flightstats/hub/webhook/ActiveWebhooksIntTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/ActiveWebhooksIntTest.java
@@ -1,6 +1,5 @@
 package com.flightstats.hub.webhook;
 
-import com.flightstats.hub.app.HubHost;
 import com.flightstats.hub.metrics.MetricsService;
 import com.flightstats.hub.test.Integration;
 import com.flightstats.hub.util.SafeZooKeeperUtils;
@@ -15,10 +14,10 @@ import java.util.List;
 import static com.google.common.collect.Sets.newHashSet;
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
-import static org.testng.AssertJUnit.assertTrue;
 
 public class ActiveWebhooksIntTest {
     private static final String WEBHOOK_LEADER_PATH = "/WebhookLeader";

--- a/src/test/java/com/flightstats/hub/webhook/ActiveWebhooksTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/ActiveWebhooksTest.java
@@ -11,9 +11,9 @@ import static java.lang.String.format;
 import static java.util.stream.Collectors.toSet;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.testng.AssertJUnit.assertTrue;
 
 public class ActiveWebhooksTest {
     private static final int HUB_PORT = HubHost.getLocalPort();

--- a/src/test/java/com/flightstats/hub/webhook/TagWebhookTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/TagWebhookTest.java
@@ -3,8 +3,8 @@ package com.flightstats.hub.webhook;
 import com.flightstats.hub.model.ChannelConfig;
 import com.flightstats.hub.test.Integration;
 import org.apache.commons.lang3.StringUtils;
-import org.testng.annotations.BeforeSuite;
-import org.testng.annotations.Test;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Set;
@@ -54,7 +54,7 @@ public class TagWebhookTest {
                 .build();
     }
 
-    @BeforeSuite
+    @Before
     public void initialize() {
         try {
             Integration.startAwsHub();


### PR DESCRIPTION
Removed TestNG library references. Now we have only Junit testing framework in our hub code. 