### PR TITLE
Add some concurrency-related safeties for StatsdReporter test

### DIFF
--- a/src/test/java/com/flightstats/hub/metrics/StatsdReporterIntegrationTest.java
+++ b/src/test/java/com/flightstats/hub/metrics/StatsdReporterIntegrationTest.java
@@ -6,6 +6,7 @@ import com.flightstats.hub.dao.Dao;
 import com.flightstats.hub.model.ChannelConfig;
 import com.flightstats.hub.util.IntegrationUdpServer;
 import com.flightstats.hub.webhook.Webhook;
+import lombok.SneakyThrows;
 import org.junit.Test;
 
 import java.util.Map;
@@ -35,13 +36,14 @@ public class StatsdReporterIntegrationTest {
     private final IntegrationUdpServer udpServer = provideNewServer(metricsConfig.getStatsdPort());
     private final IntegrationUdpServer udpServerDD = provideNewServer(metricsConfig.getDogstatsdPort());
 
+    @SneakyThrows
     @Test
-    public void StatsDHandlersCount_metricShape() throws InterruptedException, ExecutionException, TimeoutException {
+    public void StatsDHandlersCount_metricShape() {
         CompletableFuture.allOf(
                 getMetricsWriterFuture(),
                 udpServer.getServerFuture(startupCountDownLatch, executorService),
                 udpServerDD.getServerFuture(startupCountDownLatch, executorService)
-        ).get(15000, TimeUnit.MILLISECONDS);
+        ).get(5000, TimeUnit.MILLISECONDS);
 
         Map<String, String> resultsStatsd = udpServer.getResult();
         assertEquals("hub.countTest:1|c|#tag2,tag1", resultsStatsd.get("hub.countTest"));
@@ -59,7 +61,7 @@ public class StatsdReporterIntegrationTest {
     private CompletableFuture<String> getMetricsWriterFuture() {
         return CompletableFuture.supplyAsync(() -> {
             try {
-                startupCountDownLatch.await(15000, TimeUnit.MILLISECONDS);
+                startupCountDownLatch.await(1000, TimeUnit.MILLISECONDS);
             } catch (InterruptedException e) {
                 fail(e.getMessage());
             }

--- a/src/test/java/com/flightstats/hub/metrics/StatsdReporterIntegrationTest.java
+++ b/src/test/java/com/flightstats/hub/metrics/StatsdReporterIntegrationTest.java
@@ -37,9 +37,11 @@ public class StatsdReporterIntegrationTest {
 
     @Test
     public void StatsDHandlersCount_metricShape() throws InterruptedException, ExecutionException, TimeoutException {
-        CompletableFuture<String> metricsWriter = getMetricsWriterFuture();
-        CompletableFuture.allOf(metricsWriter, udpServer.getServerFuture(), udpServerDD.getServerFuture())
-                .get(15000, TimeUnit.MILLISECONDS);
+        CompletableFuture.allOf(
+                getMetricsWriterFuture(),
+                udpServer.getServerFuture(startupCountDownLatch, executorService),
+                udpServerDD.getServerFuture(startupCountDownLatch, executorService)
+        ).get(15000, TimeUnit.MILLISECONDS);
 
         Map<String, String> resultsStatsd = udpServer.getResult();
         assertEquals("hub.countTest:1|c|#tag2,tag1", resultsStatsd.get("hub.countTest"));
@@ -50,10 +52,7 @@ public class StatsdReporterIntegrationTest {
 
     private IntegrationUdpServer provideNewServer(int port) {
         return IntegrationUdpServer.builder()
-                .listening(true)
                 .port(port)
-                .startupCountDownLatch(startupCountDownLatch)
-                .executorService(executorService)
                 .build();
     }
 

--- a/src/test/java/com/flightstats/hub/metrics/StatsdReporterIntegrationTest.java
+++ b/src/test/java/com/flightstats/hub/metrics/StatsdReporterIntegrationTest.java
@@ -6,35 +6,48 @@ import com.flightstats.hub.dao.Dao;
 import com.flightstats.hub.model.ChannelConfig;
 import com.flightstats.hub.util.IntegrationUdpServer;
 import com.flightstats.hub.webhook.Webhook;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.sql.Time;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
+@Slf4j
 public class StatsdReporterIntegrationTest {
-    private static String[] tags = { "tag1", "tag2" };
-    private static Map<String, String> resultsStatsd;
-    private static Map<String, String> resultsDogStatsd;
-    private static MetricsConfig metricsConfig = MetricsConfig.builder()
+    private String[] tags = { "tag1", "tag2" };
+    private Map<String, String> resultsStatsd;
+    private Map<String, String> resultsDogStatsd;
+    private MetricsConfig metricsConfig = MetricsConfig.builder()
             .hostTag("test_host")
             .statsdPort(8123)
             .dogstatsdPort(8122)
             .build();
 
-    private static IntegrationUdpServer provideNewServer(int port) {
+    private IntegrationUdpServer provideNewServer(int port, CountDownLatch startupCountDownLatch, AtomicBoolean canListen, ExecutorService executorService) {
         return IntegrationUdpServer.builder()
-                .timeoutMillis(5000)
-                .listening(true)
+                .listening(new AtomicBoolean(true))
                 .port(port)
+                .startupCountDownLatch(startupCountDownLatch)
+                .canListen(canListen)
+                .executorService(executorService)
                 .build();
     }
 
     @SuppressWarnings("unchecked")
-    private static StatsdReporter provideStatsDHandlers() {
+    private StatsdReporter provideStatsDHandlers() {
         Dao<ChannelConfig> channelConfigDao = (Dao<ChannelConfig>) mock(CachedLowerCaseDao.class);
         Dao<Webhook> webhookDao =  (Dao<Webhook>) mock(CachedDao.class);
         StatsDFilter statsDFilter = new StatsDFilter(metricsConfig, channelConfigDao, webhookDao);
@@ -43,26 +56,43 @@ public class StatsdReporterIntegrationTest {
         return provider.get();
     }
 
-    private static void runAfterSocketInit(Runnable runnable) {
-        Executors.newScheduledThreadPool(1).schedule(runnable, 100, TimeUnit.MILLISECONDS);
-    }
-
-
-    @BeforeClass
-    public static void startMockStatsDServer() {
+    public void startMockStatsDServer() throws InterruptedException, ExecutionException, TimeoutException {
+        CountDownLatch startupCountDownLatch = new CountDownLatch(2);
+        AtomicBoolean canListen = new AtomicBoolean();
         StatsdReporter handlers = provideStatsDHandlers();
-        IntegrationUdpServer udpServer = provideNewServer(metricsConfig.getStatsdPort());
-        IntegrationUdpServer udpServerDD = provideNewServer(metricsConfig.getDogstatsdPort());
-        runAfterSocketInit(() -> {
+        ExecutorService executorService = Executors.newFixedThreadPool(3);
+        IntegrationUdpServer udpServer = provideNewServer(metricsConfig.getStatsdPort(), startupCountDownLatch, canListen, executorService);
+        IntegrationUdpServer udpServerDD = provideNewServer(metricsConfig.getDogstatsdPort(), startupCountDownLatch, canListen, executorService);
+        CompletableFuture<String> sender = CompletableFuture.supplyAsync(() -> {
+            try {
+                startupCountDownLatch.await(15000, TimeUnit.MILLISECONDS);
+                log.info("yay");
+                log.info(Long.valueOf(startupCountDownLatch.getCount()).toString());
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+                log.error(e.getMessage());
+                fail();
+            }
+            log.info("gonna count now");
             handlers.count("countTest", 1, tags);
             handlers.increment("closeSocket", tags);
-        });
+            log.info("done with handlers");
+            canListen.set(true);
+            return "done";
+        }, executorService);
+        log.info("about to get futures");
+        CompletableFuture.allOf(sender, udpServer.getServerFuture(), udpServerDD.getServerFuture())
+                .get(15000, TimeUnit.MILLISECONDS);
+        log.info(String.valueOf(startupCountDownLatch.getCount()));
+        Thread.sleep(500);
         resultsStatsd = udpServer.getResult();
         resultsDogStatsd = udpServerDD.getResult();
     }
 
     @Test
-    public void StatsDHandlersCount_metricShape() {
+    public void StatsDHandlersCount_metricShape() throws InterruptedException, ExecutionException, TimeoutException {
+        startMockStatsDServer();
+        log.info("asserting");
         assertEquals("hub.countTest:1|c|#tag2,tag1", resultsStatsd.get("hub.countTest"));
         assertEquals("hub.countTest:1|c|#tag2,tag1", resultsDogStatsd.get("hub.countTest"));
     }

--- a/src/test/java/com/flightstats/hub/metrics/StatsdReporterIntegrationTest.java
+++ b/src/test/java/com/flightstats/hub/metrics/StatsdReporterIntegrationTest.java
@@ -7,10 +7,8 @@ import com.flightstats.hub.model.ChannelConfig;
 import com.flightstats.hub.util.IntegrationUdpServer;
 import com.flightstats.hub.webhook.Webhook;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.sql.Time;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -25,23 +23,25 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
-@Slf4j
 public class StatsdReporterIntegrationTest {
     private String[] tags = { "tag1", "tag2" };
-    private Map<String, String> resultsStatsd;
-    private Map<String, String> resultsDogStatsd;
     private MetricsConfig metricsConfig = MetricsConfig.builder()
             .hostTag("test_host")
             .statsdPort(8123)
             .dogstatsdPort(8122)
             .build();
 
-    private IntegrationUdpServer provideNewServer(int port, CountDownLatch startupCountDownLatch, AtomicBoolean canListen, ExecutorService executorService) {
+    private final CountDownLatch startupCountDownLatch = new CountDownLatch(2);
+    private final ExecutorService executorService = Executors.newFixedThreadPool(3);
+
+    private final IntegrationUdpServer udpServer = provideNewServer(metricsConfig.getStatsdPort());
+    private final IntegrationUdpServer udpServerDD = provideNewServer(metricsConfig.getDogstatsdPort());
+
+    private IntegrationUdpServer provideNewServer(int port) {
         return IntegrationUdpServer.builder()
-                .listening(new AtomicBoolean(true))
+                .listening(true)
                 .port(port)
                 .startupCountDownLatch(startupCountDownLatch)
-                .canListen(canListen)
                 .executorService(executorService)
                 .build();
     }
@@ -56,45 +56,34 @@ public class StatsdReporterIntegrationTest {
         return provider.get();
     }
 
-    public void startMockStatsDServer() throws InterruptedException, ExecutionException, TimeoutException {
-        CountDownLatch startupCountDownLatch = new CountDownLatch(2);
-        AtomicBoolean canListen = new AtomicBoolean();
-        StatsdReporter handlers = provideStatsDHandlers();
-        ExecutorService executorService = Executors.newFixedThreadPool(3);
-        IntegrationUdpServer udpServer = provideNewServer(metricsConfig.getStatsdPort(), startupCountDownLatch, canListen, executorService);
-        IntegrationUdpServer udpServerDD = provideNewServer(metricsConfig.getDogstatsdPort(), startupCountDownLatch, canListen, executorService);
-        CompletableFuture<String> sender = CompletableFuture.supplyAsync(() -> {
-            try {
-                startupCountDownLatch.await(15000, TimeUnit.MILLISECONDS);
-                log.info("yay");
-                log.info(Long.valueOf(startupCountDownLatch.getCount()).toString());
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-                log.error(e.getMessage());
-                fail();
-            }
-            log.info("gonna count now");
-            handlers.count("countTest", 1, tags);
-            handlers.increment("closeSocket", tags);
-            log.info("done with handlers");
-            canListen.set(true);
-            return "done";
-        }, executorService);
-        log.info("about to get futures");
-        CompletableFuture.allOf(sender, udpServer.getServerFuture(), udpServerDD.getServerFuture())
-                .get(15000, TimeUnit.MILLISECONDS);
-        log.info(String.valueOf(startupCountDownLatch.getCount()));
-        Thread.sleep(500);
-        resultsStatsd = udpServer.getResult();
-        resultsDogStatsd = udpServerDD.getResult();
-    }
-
     @Test
     public void StatsDHandlersCount_metricShape() throws InterruptedException, ExecutionException, TimeoutException {
-        startMockStatsDServer();
-        log.info("asserting");
+        CompletableFuture<String> metricsWriter = getMetricsWriterFuture();
+        CompletableFuture.allOf(metricsWriter, udpServer.getServerFuture(), udpServerDD.getServerFuture())
+                .get(15000, TimeUnit.MILLISECONDS);
+
+        Map<String, String> resultsStatsd = udpServer.getResult();
         assertEquals("hub.countTest:1|c|#tag2,tag1", resultsStatsd.get("hub.countTest"));
+
+        Map<String, String> resultsDogStatsd = udpServerDD.getResult();
         assertEquals("hub.countTest:1|c|#tag2,tag1", resultsDogStatsd.get("hub.countTest"));
     }
 
+    private CompletableFuture<String> getMetricsWriterFuture() {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                startupCountDownLatch.await(15000, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                fail(e.getMessage());
+            }
+            writeMetrics();
+            return "done";
+        }, executorService);
+    }
+
+    private void writeMetrics() {
+        StatsdReporter handlers = provideStatsDHandlers();
+        handlers.count("countTest", 1, tags);
+        handlers.increment("closeSocket", tags);
+    }
 }

--- a/src/test/java/com/flightstats/hub/util/IntegrationUdpServer.java
+++ b/src/test/java/com/flightstats/hub/util/IntegrationUdpServer.java
@@ -24,7 +24,7 @@ public class IntegrationUdpServer {
 
     private final Map<String, String> store = new HashMap<>();
 
-    public CompletableFuture<Map<String, String>> getServerFuture(final CountDownLatch startupCountDownLatch, final ExecutorService executorService) {
+    public CompletableFuture<Map<String, String>> getServerFuture(CountDownLatch startupCountDownLatch, ExecutorService executorService) {
         return  CompletableFuture.supplyAsync(() -> {
             boolean listening = true;
             try {

--- a/src/test/java/com/flightstats/hub/util/IntegrationUdpServer.java
+++ b/src/test/java/com/flightstats/hub/util/IntegrationUdpServer.java
@@ -2,17 +2,13 @@ package com.flightstats.hub.util;
 
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.net.DatagramPacket;
@@ -20,7 +16,6 @@ import java.net.DatagramSocket;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 @Slf4j

--- a/src/test/java/com/flightstats/hub/util/IntegrationUdpServer.java
+++ b/src/test/java/com/flightstats/hub/util/IntegrationUdpServer.java
@@ -36,7 +36,6 @@ public class IntegrationUdpServer {
             while (listening) {
                 byte[] data = new byte[70];
                 String result = openSocket(data, serverSocket);
-                Thread.sleep(500);
                 addValueToStore(result);
             }
         } catch(Exception ex) {

--- a/src/test/java/com/flightstats/hub/util/IntegrationUdpServer.java
+++ b/src/test/java/com/flightstats/hub/util/IntegrationUdpServer.java
@@ -26,10 +26,9 @@ public class IntegrationUdpServer {
 
     public CompletableFuture<Map<String, String>> getServerFuture(CountDownLatch startupCountDownLatch, ExecutorService executorService) {
         return  CompletableFuture.supplyAsync(() -> {
-            boolean listening = true;
             try {
                 DatagramSocket serverSocket = new DatagramSocket(port);
-                while (listening) {
+                while (true) {
                     byte[] data = new byte[70];
                     DatagramPacket receivePacket = new DatagramPacket(data, data.length);
                     startupCountDownLatch.countDown();
@@ -39,13 +38,12 @@ public class IntegrationUdpServer {
                     addValueToStore(result);
 
                     if (result.contains("closeSocket")) {
-                        listening = false;
+                        break;
                     }
                 }
             } catch (Exception e) {
                 log.error("error listening on port %s", port, e);
             }
-//        log.info(":::::::::, {}", store);
             return store;
         }, executorService);
     }

--- a/src/test/java/com/flightstats/hub/util/IntegrationUdpServer.java
+++ b/src/test/java/com/flightstats/hub/util/IntegrationUdpServer.java
@@ -1,6 +1,7 @@
 package com.flightstats.hub.util;
 
 import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,9 +23,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Builder
 public class IntegrationUdpServer {
-    private final static Logger logger = LoggerFactory.getLogger(IntegrationUdpServer.class);
     private int port;
     private boolean listening;
     private CountDownLatch startupCountDownLatch;
@@ -48,7 +49,7 @@ public class IntegrationUdpServer {
             } catch (IOException e) {
                 listening = false;
             }
-//        logger.info(":::::::::, {}", store);
+//        log.info(":::::::::, {}", store);
             return store;
         }, executorService);
     }
@@ -59,7 +60,6 @@ public class IntegrationUdpServer {
         BufferedReader reader = new BufferedReader(streamReader);
         String result = reader
                 .lines()
-                .peek(logger::info)
                 .collect(Collectors.toList())
                 .get(0)
                 .trim();
@@ -70,7 +70,6 @@ public class IntegrationUdpServer {
 
         reader.close();
         streamReader.close();
-        logger.info(result);
         return result;
     }
 


### PR DESCRIPTION
After Damon's changes, I was still getting consistent failures here. I threw some more concurrency-related stuff in and removed `Thread.sleep`s. It seems more stable now.

In the process of debugging, I ended up inlining the BeforeClass method, which likely decreases debuggability, but I found it difficult with all the `CompletableFuture`s already. :-/