### PR TITLE
Support setting HUB_RMI_HOST_IP as an environment variable when launc…

### DIFF
--- a/docker/run
+++ b/docker/run
@@ -10,6 +10,7 @@ CONFIG_DIR=/etc/hub
 # LOG_DIR also exists in logback.xml
 LOG_DIR=/mnt/log
 DEBUG_PORT=3333
+HOST_IP=${HUB_RMI_HOST_IP:=disabled.host.for.rmi}
 JMXREMOTE_PORT=8888
 
 # extract the port from hub.properties
@@ -40,7 +41,10 @@ JAVA_OPTS="
  -agentlib:jdwp=transport=dt_socket,address=$DEBUG_PORT,server=y,suspend=n
  -Djboss.platform.mbeanserver
  -Dcom.sun.management.jmxremote
+ -Dcom.sun.management.jmxremote.local.only=false
+ -Djava.rmi.server.hostname=$HOST_IP
  -Dcom.sun.management.jmxremote.port=$JMXREMOTE_PORT
+ -Dcom.sun.management.jmxremote.rmi.port=$JMXREMOTE_PORT
  -Dcom.sun.management.jmxremote.ssl=false
  -Dcom.sun.management.jmxremote.authenticate=false
  -XX:+PrintGCDetails


### PR DESCRIPTION
…hing docker to get it to expose its JMX controls at that IP:8888.  You must bind 8888 to the same port on the host box.  Authentication is NOT enabled, so probably avoid this in prod.