### PR TITLE
Sometimes the hub tries the item with the bad callback url more than once.

### DIFF
--- a/src/test/javascript/integration/webhook_change_url_spec.js
+++ b/src/test/javascript/integration/webhook_change_url_spec.js
@@ -83,8 +83,8 @@ describe(__filename, () => {
         expect(lastCompleted).toContain('initial');
         expect(inFlight.length).toEqual(1);
         expect(inFlight[0]).toEqual(postedItems[0]);
-        expect(errors.length).toEqual(1);
-        expect(errors[0]).toContain('java.net.UnknownHostException');
+        expect(errors.length).toBeGreaterThanOrEqual(1);
+        expect(errors.some(item => item.includes('java.net.UnknownHostException'))).toBeTruthy();
     });
 
     it('creates a callback server', async () => {


### PR DESCRIPTION
Let's accept that as normal behavior.