### PR TITLE
Fix /latest query not honoring cache if channel is empty, causing an …

### DIFF
--- a/src/main/java/com/flightstats/hub/dao/aws/ClusterContentService.java
+++ b/src/main/java/com/flightstats/hub/dao/aws/ClusterContentService.java
@@ -420,14 +420,11 @@ public class ClusterContentService implements ContentService {
         ContentPath latestCache = latestContentCache.getLatest(channel, null);
         ActiveTraces.getLocal().add("found latestCache", channel, latestCache);
         if (latestCache != null) {
-            // TODO: Inconsistent read.  This uses a value it considers stale, but guarantees subsequent reads will not use it.
-            if (latestCache.getTime().isBefore(channelTtlTime)) {
+            if (channelTtlTime != null && latestCache.getTime().isBefore(channelTtlTime)) {
                 latestContentCache.setEmpty(channel);   // if the newest thing (latest) is expired, then the channel is now empty
+                latestCache = ContentKey.NONE;
             }
             ActiveTraces.getLocal().add("found cached latest", channel, latestCache);
-            if (latestCache.equals(ContentKey.NONE)) {
-                return Optional.empty();
-            }
         }
         return Optional.ofNullable((ContentKey) latestCache);
     }

--- a/src/test/java/com/flightstats/hub/dao/aws/ClusterContentServiceTest.java
+++ b/src/test/java/com/flightstats/hub/dao/aws/ClusterContentServiceTest.java
@@ -177,7 +177,7 @@ class ClusterContentServiceTest {
         ContentKey startKey = new ContentKey(TimeUtil.now().minusSeconds(20), "StartKey");
         DirectionQuery query = DirectionQuery.builder().channelName(channelName).stable(true).startKey(startKey).build();
         stubRealChannel();
-        stubCachedEmptyChannelLatest();
+        when(latestContentCache.getLatest(channelName, null)).thenReturn(ContentKey.NONE);
         Optional<ContentKey> latest = ccs.getLatestImmutable(query);
         assertTrue(latest.isPresent());
         assertEquals(ContentKey.NONE, latest.get());
@@ -281,10 +281,6 @@ class ClusterContentServiceTest {
         ContentKey cachedKey = new ContentKey(TimeUtil.now().minusSeconds(ageInSeconds), keyName);
         when(latestContentCache.getLatest(channelName, null)).thenReturn(cachedKey);
         return cachedKey;
-    }
-
-    private void stubCachedEmptyChannelLatest() {
-        when(latestContentCache.getLatest(channelName, null)).thenReturn(ContentKey.NONE);
     }
 
     private ContentKey stubLongTermLatest(int ageInSeconds, String keyName) {


### PR DESCRIPTION
…S3 hit.