### PR TITLE
configurable offset minutes for s3 lifecycle rule management scheduler

### DIFF
--- a/configs/aws-hub.properties
+++ b/configs/aws-hub.properties
@@ -145,5 +145,8 @@ s3.environment=east1
 #s3Verifier.offsetMinutes=15
 # Number of threads to process at one time, used to throttle impact
 #s3Verifier.channelThreads=3
+# default is 660, how often to run s3 lifecycle rules management service
+# not recommended to set except for tests, must be a positive round number
+#s3.lifecycleRulesManager.offset.minutes=660
 # optional - set this to HTTPS if you have sensitive data
 aws.protocol=HTTP

--- a/configs/aws-hub.properties
+++ b/configs/aws-hub.properties
@@ -145,8 +145,8 @@ s3.environment=east1
 #s3Verifier.offsetMinutes=15
 # Number of threads to process at one time, used to throttle impact
 #s3Verifier.channelThreads=3
-# default is 660, how often to run s3 lifecycle rules management service
+# default is 360, how often to run s3 lifecycle rules management service
 # not recommended to set except for tests, must be a positive round number
-#s3.lifecycleRulesManager.offset.minutes=660
+#s3.ttlEnforcer.offset.minutes=660
 # optional - set this to HTTPS if you have sensitive data
 aws.protocol=HTTP

--- a/configs/aws-hub.properties
+++ b/configs/aws-hub.properties
@@ -147,6 +147,6 @@ s3.environment=east1
 #s3Verifier.channelThreads=3
 # default is 360, how often to run s3 lifecycle rules management service
 # not recommended to set except for tests, must be a positive round number
-#s3.ttlEnforcer.offset.minutes=660
+#s3.ttlEnforcer.offset.minutes=360
 # optional - set this to HTTPS if you have sensitive data
 aws.protocol=HTTP

--- a/src/main/java/com/flightstats/hub/config/properties/S3Properties.java
+++ b/src/main/java/com/flightstats/hub/config/properties/S3Properties.java
@@ -101,4 +101,6 @@ public class S3Properties {
         return propertiesLoader.getProperty("s3.maxChunkMB", 40);
     }
 
+    public long getLifecycleRulesManagerOffsetMinutes() { return propertiesLoader.getProperty("s3.lifecycleRulesManager.offset.minutes", 60 * 6); }
+
 }

--- a/src/main/java/com/flightstats/hub/config/properties/S3Properties.java
+++ b/src/main/java/com/flightstats/hub/config/properties/S3Properties.java
@@ -101,6 +101,6 @@ public class S3Properties {
         return propertiesLoader.getProperty("s3.maxChunkMB", 40);
     }
 
-    public long getLifecycleRulesManagerOffsetMinutes() { return propertiesLoader.getProperty("s3.lifecycleRulesManager.offset.minutes", 60 * 6); }
+    public long getS3TtlEnforcerOffsetMinutes() { return propertiesLoader.getProperty("s3.ttlEnforcer.offset.minutes", 60 * 6); }
 
 }

--- a/src/main/java/com/flightstats/hub/dao/aws/S3Config.java
+++ b/src/main/java/com/flightstats/hub/dao/aws/S3Config.java
@@ -40,7 +40,7 @@ public class S3Config {
     private final ContentRetriever contentRetriever;
     private final ChannelService channelService;
     private final S3Properties s3Properties;
-    private final long lifecycleRulesManagerOffsetMinutes;
+    private final long s3TtlEnforcerOffsetMinutes;
 
     @Inject
     public S3Config(HubS3Client s3Client,
@@ -55,7 +55,7 @@ public class S3Config {
         this.channelService = channelService;
         this.contentRetriever = contentRetriever;
         this.s3Properties = s3Properties;
-        this.lifecycleRulesManagerOffsetMinutes = s3Properties.getLifecycleRulesManagerOffsetMinutes();
+        this.s3TtlEnforcerOffsetMinutes = s3Properties.getS3TtlEnforcerOffsetMinutes();
         if (s3Properties.isConfigManagementEnabled()) {
             HubServices.register(new S3ConfigInit());
         }
@@ -85,8 +85,8 @@ public class S3Config {
 
         @Override
         protected Scheduler scheduler() {
-            long delayMinutes = lifecycleRulesManagerOffsetMinutes +
-                    ThreadLocalRandom.current().nextLong(lifecycleRulesManagerOffsetMinutes);
+            long delayMinutes = s3TtlEnforcerOffsetMinutes +
+                    ThreadLocalRandom.current().nextLong(s3TtlEnforcerOffsetMinutes);
             log.info("scheduling S3Config with delay " + delayMinutes);
             return Scheduler.newFixedDelaySchedule(0, delayMinutes, TimeUnit.MINUTES);
         }


### PR DESCRIPTION
allows for scheduling maxItems cleanup to run more frequently so that it can be tested in a reasonable window of time. This is a spike for the sake of the tests, more refactoring in the "S3Config" and related classes is slated in more involved stories