### PR TITLE
add more statsd event logging around hub startup

### DIFF
--- a/src/main/java/com/flightstats/hub/app/ShutdownManager.java
+++ b/src/main/java/com/flightstats/hub/app/ShutdownManager.java
@@ -46,7 +46,7 @@ public class ShutdownManager {
 
     public boolean shutdown(boolean useLock) throws Exception {
         log.warn("shutting down!");
-        String[] tags = {"restart", "shutdown"};
+        String[] tags = {"restart", "shutdown", "app-lifecycle"};
         statsdReporter.event("Hub Restart Shutdown", "shutting down", tags);
         statsdReporter.mute();
 

--- a/src/main/java/com/flightstats/hub/config/server/HubServer.java
+++ b/src/main/java/com/flightstats/hub/config/server/HubServer.java
@@ -3,6 +3,7 @@ package com.flightstats.hub.config.server;
 import com.flightstats.hub.app.HubServices;
 import com.flightstats.hub.app.ShutdownManager;
 import com.flightstats.hub.config.ServiceRegistration;
+import com.flightstats.hub.metrics.StatsdReporter;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jetty.server.Server;
 
@@ -14,15 +15,18 @@ public class HubServer {
 
     private final ShutdownManager shutdownManager;
     private final ServiceRegistration serviceRegistration;
+    private final StatsdReporter statsdReporter;
     private final JettyServer jettyServer;
     private Server server;
 
     @Inject
     public HubServer(ShutdownManager shutdownManager,
                      ServiceRegistration serviceRegistration,
+                     StatsdReporter statsdReporter,
                      JettyServer jettyServer) {
         this.shutdownManager = shutdownManager;
         this.serviceRegistration = serviceRegistration;
+        this.statsdReporter = statsdReporter;
         this.jettyServer = jettyServer;
     }
 
@@ -31,6 +35,10 @@ public class HubServer {
 
         serviceRegistration.register();
         HubServices.start(HubServices.TYPE.BEFORE_HEALTH_CHECK);
+
+        String[] tags = {"startup", "restart", "app-lifecycle"};
+        statsdReporter.event("Hub Startup", "starting", tags);
+
         server = jettyServer.start();
         log.info("Hub server has been started.");
 
@@ -38,6 +46,8 @@ public class HubServer {
         log.info("jHub Server health check is complete");
         HubServices.start(HubServices.TYPE.AFTER_HEALTHY_START);
         log.info("jHub Server services have been started successfully");
+
+        statsdReporter.event("Hub Startup Successful", "started", tags);
     }
 
     public void stop() throws Exception {


### PR DESCRIPTION
We have a statsd event in the shutdown manager (https://app.datadoghq.com/event/stream?tags_execution=and&show_private=true&per_page=30&query=tags%3Acluster%3Aiad.staging%2Crestart%20hub%20priority%3Aall%20status%3Aall&aggregate_up=true&use_date_happened=false&display_timeline=true&from_ts=1561553760000&priority=normal&live=true&is_zoomed=false&status=all&to_ts=1561568160000&is_auto=false&incident=true&only_discussed=false&no_user=false&page=0&bucket_size=240000) , but we don't have anything that tracks startup.

I was debating between "events" and using a counter of some sort so we can create an alert on high rates of restarts. This way follows the existing pattern... What do you think?