### PR TITLE
add an artifact on OoM exit

### DIFF
--- a/docker/run
+++ b/docker/run
@@ -35,6 +35,8 @@ JAVA_OPTS="
  -XX:NewSize=$NEW_SIZE
  -XX:+UseG1GC
  -XX:MaxGCPauseMillis=100
+ -XX:+HeapDumpOnOutOfMemoryError
+ -XX:HeapDumpPath=/mnt/log
  -XX:+ExitOnOutOfMemoryError
  -Dsun.rmi.dgc.client.gcInterval=300000
  -Dsun.rmi.dgc.server.gcInterval=300000


### PR DESCRIPTION
We had a crash/restart loop recently that happened due to OutOfMem errors.
The root cause was hard to find and more introspection is somewhat a matter of educated guessing from there. Hopefully this will make it easier in the future.