### PR TITLE
Add system tests for next/previous second behavior

### DIFF
--- a/src/systemTest/java/com/flightstats/hub/model/ChannelItemPathParts.java
+++ b/src/systemTest/java/com/flightstats/hub/model/ChannelItemPathParts.java
@@ -9,9 +9,12 @@ import org.joda.time.DateTime;
 import java.util.Optional;
 import java.util.function.Function;
 
+import static java.lang.String.format;
+
 @Value
 @Builder
 public class ChannelItemPathParts {
+    String itemUrl;
     String path;
 
     public String getChannelName() {
@@ -27,6 +30,11 @@ public class ChannelItemPathParts {
                 .replace(getChannelName(), "")
                 .replace(getHashKey(), "")
                 .substring(1);
+    }
+
+    public String getSecondUrl() {
+        String overlyGranularPathParts = format("%03d/%s", getMillis(), getHashKey());
+        return getItemUrl().substring(0, getItemUrl().indexOf(overlyGranularPathParts) - 1);
     }
 
     public DateTime getDateTime() {
@@ -63,7 +71,6 @@ public class ChannelItemPathParts {
 
     public static class ChannelItemPathPartsBuilder {
         private HttpUrl baseUrl;
-        private String itemUrl;
 
         public ChannelItemPathPartsBuilder baseUrl(HttpUrl baseUrl) {
             this.baseUrl = baseUrl;

--- a/src/systemTest/java/com/flightstats/hub/model/ChannelItemWithBody.java
+++ b/src/systemTest/java/com/flightstats/hub/model/ChannelItemWithBody.java
@@ -2,10 +2,38 @@ package com.flightstats.hub.model;
 
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.Delegate;
+import okhttp3.HttpUrl;
 
 @Builder
 @Value
 public class ChannelItemWithBody {
-    String url;
+    @Delegate
+    ChannelItemPathParts pathParts;
+
     Object body;
+
+    public static class ChannelItemWithBodyBuilder {
+        private String itemUrl;
+        private HttpUrl baseUrl;
+
+        public ChannelItemWithBodyBuilder baseUrl(HttpUrl baseUrl) {
+            this.baseUrl = baseUrl;
+            setPathParts();
+            return this;
+        }
+
+        public ChannelItemWithBodyBuilder itemUrl(String itemUrl) {
+            this.itemUrl = itemUrl;
+            setPathParts();
+            return this;
+        }
+
+        private void setPathParts() {
+            pathParts = ChannelItemPathParts.builder()
+                    .baseUrl(baseUrl)
+                    .itemUrl(itemUrl)
+                    .build();
+        }
+    }
 }

--- a/src/systemTest/java/com/flightstats/hub/system/service/ChannelItemCreator.java
+++ b/src/systemTest/java/com/flightstats/hub/system/service/ChannelItemCreator.java
@@ -74,7 +74,8 @@ public class ChannelItemCreator {
         assertNotNull(response.body());
 
         return ChannelItemWithBody.builder()
-                .url(response.body().get_links().getSelf().getHref())
+                .baseUrl(hubBaseUrl)
+                .itemUrl(response.body().get_links().getSelf().getHref())
                 .body(itemIdentifier)
                 .build();
     }
@@ -98,7 +99,7 @@ public class ChannelItemCreator {
 
     private DateTime getDateTimeForItem(ChannelItemWithBody channelItem) {
         return ChannelItemPathParts.builder()
-                .itemUrl(channelItem.getUrl())
+                .itemUrl(channelItem.getPath())
                 .baseUrl(hubBaseUrl)
                 .build()
                 .getDateTime();


### PR DESCRIPTION
I originally thought that you could ask for next items with less granularity (hours or days). I also, for some reason, thought it'd show you the next items and not the next second. Turns out both of those things are wrong, so parameterized tests didn't make sense.