### PR TITLE
Bump nokogiri from 1.10.1 to 1.10.4 in /docs

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -205,7 +205,7 @@ GEM
       jekyll-seo-tag (~> 2.1)
     minitest (5.11.3)
     multipart-post (2.0.0)
-    nokogiri (1.10.1)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     octokit (4.13.0)
       sawyer (~> 0.8.0, >= 0.5.3)


### PR DESCRIPTION
Reopening to rename branch, dependabot creates invalid branch names for our CI

Bumps [nokogiri](https://github.com/sparklemotion/nokogiri) from 1.10.1 to 1.10.4.
- [Release notes](https://github.com/sparklemotion/nokogiri/releases)
- [Changelog](https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.md)
- [Commits](https://github.com/sparklemotion/nokogiri/compare/v1.10.1...v1.10.4)

Signed-off-by: dependabot[bot] <support@github.com>