### PR TITLE
Add prefix to s3 lifecycles rules crated by hub

### DIFF
--- a/src/main/java/com/flightstats/hub/dao/aws/HubS3Client.java
+++ b/src/main/java/com/flightstats/hub/dao/aws/HubS3Client.java
@@ -5,11 +5,13 @@ import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.S3ResponseMetadata;
 import com.amazonaws.services.s3.model.AbortMultipartUploadRequest;
+import com.amazonaws.services.s3.model.BucketLifecycleConfiguration;
 import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
 import com.amazonaws.services.s3.model.CompleteMultipartUploadResult;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import com.amazonaws.services.s3.model.DeleteObjectsResult;
+import com.amazonaws.services.s3.model.GetBucketLifecycleConfigurationRequest;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
 import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
@@ -23,9 +25,9 @@ import com.amazonaws.services.s3.model.UploadPartRequest;
 import com.amazonaws.services.s3.model.UploadPartResult;
 import com.flightstats.hub.config.properties.S3Properties;
 import com.flightstats.hub.metrics.StatsdReporter;
-import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -152,6 +154,15 @@ public class HubS3Client {
             s3Client.setBucketLifecycleConfiguration(request);
         } catch (SdkClientException e) {
             countError(e, request, "setBucketLifecycleConfiguration", Collections.singletonList("bucket:" + request.getBucketName()));
+            throw e;
+        }
+    }
+
+    BucketLifecycleConfiguration getBucketLifecycleConfiguration(GetBucketLifecycleConfigurationRequest request) {
+        try {
+            return s3Client.getBucketLifecycleConfiguration(request);
+        } catch (SdkClientException e) {
+            countError(e, request, "getBucketLifecycleConfiguration", Collections.singletonList("bucket:" + bucketName));
             throw e;
         }
     }

--- a/src/main/java/com/flightstats/hub/dao/aws/S3ConfigStrategy.java
+++ b/src/main/java/com/flightstats/hub/dao/aws/S3ConfigStrategy.java
@@ -12,12 +12,14 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 class S3ConfigStrategy {
 
-    public final static String BATCH_POSTFIX = "Batch";
-    public final static String SINGLE_POSTFIX = "";
+    final static String BATCH_POSTFIX = "Batch";
+    final static String SINGLE_POSTFIX = "";
+    final static String BUCKET_LIFECYCLE_RULE_PREFIX = "HUB_";
 
     static List<BucketLifecycleConfiguration.Rule> apportion(Iterable<ChannelConfig> channelConfigs, DateTime timeForSharding, int max) {
         List<BucketLifecycleConfiguration.Rule> rules = new ArrayList<>();
@@ -82,8 +84,26 @@ class S3ConfigStrategy {
     private static BucketLifecycleConfiguration.Rule createRule(ChannelConfig config, String id) {
         return new BucketLifecycleConfiguration.Rule()
                 .withFilter(new LifecycleFilter(new LifecyclePrefixPredicate(id + "/")))
-                .withId(id)
+                .withId(BUCKET_LIFECYCLE_RULE_PREFIX.concat(id))
                 .withExpirationInDays((int) config.getTtlDays())
                 .withStatus(BucketLifecycleConfiguration.ENABLED);
+    }
+
+    /**
+     * S3 Bucket lifecycle rules limit                         = 1000 per bucket
+     * Max S3 Bucket lifecycle rules Hub can create            = 990
+     * Max S3 Bucket lifecycle rules terraform code can create = 10
+     * The lifecycle rules created in hub only expires the objects based on TTL days configuration in hub channel.
+     * The expiration action in S3 adds delete marker to current object and does not delete it.
+     * The lifecycle rules set in terraform code cleans up all the delete markers and previous versions of the object in the S3 bucket.
+     **/
+    static List<BucketLifecycleConfiguration.Rule> getNonHubBucketLifecycleRules(BucketLifecycleConfiguration config) {
+        List<BucketLifecycleConfiguration.Rule> currentBucketLifecycleRules = config.getRules();
+        List<BucketLifecycleConfiguration.Rule> filteredRules =
+                currentBucketLifecycleRules
+                        .parallelStream()
+                        .filter(rule -> !rule.getId().contains(BUCKET_LIFECYCLE_RULE_PREFIX))
+                        .collect(Collectors.toList());
+        return filteredRules.size() < 10 ? filteredRules : filteredRules.subList(0, 10);
     }
 }

--- a/src/main/java/com/flightstats/hub/dao/aws/S3ConfigStrategy.java
+++ b/src/main/java/com/flightstats/hub/dao/aws/S3ConfigStrategy.java
@@ -99,11 +99,10 @@ class S3ConfigStrategy {
      **/
     static List<BucketLifecycleConfiguration.Rule> getNonHubBucketLifecycleRules(BucketLifecycleConfiguration config) {
         List<BucketLifecycleConfiguration.Rule> currentBucketLifecycleRules = config.getRules();
-        List<BucketLifecycleConfiguration.Rule> filteredRules =
-                currentBucketLifecycleRules
+        return currentBucketLifecycleRules
                         .parallelStream()
-                        .filter(rule -> !rule.getId().contains(BUCKET_LIFECYCLE_RULE_PREFIX))
+                        .filter(rule -> !rule.getId().startsWith(BUCKET_LIFECYCLE_RULE_PREFIX))
+                        .limit(10)
                         .collect(Collectors.toList());
-        return filteredRules.size() < 10 ? filteredRules : filteredRules.subList(0, 10);
     }
 }


### PR DESCRIPTION
Add prefix to s3 bucket lifecycle rules created by the HUB. This will help us to distinguish the s3 bucket lifecycle rules created externally (Outside HUB. From terraform code.)