### PR TITLE
Clean up some webhook validation tests

### DIFF
--- a/src/main/java/com/flightstats/hub/webhook/WebhookValidator.java
+++ b/src/main/java/com/flightstats/hub/webhook/WebhookValidator.java
@@ -27,20 +27,9 @@ public class WebhookValidator {
         this.webhookProperties = webhookProperties;
     }
 
-    private void isValidCallbackTimeoutSeconds(int value) {
-        int minimum = webhookProperties.getCallbackTimeoutMinimum();
-        int maximum = webhookProperties.getCallbackTimeoutMaximum();
-        if (isOutsideRange(value, minimum, maximum)) {
-            throw new InvalidRequestException("callbackTimeoutSeconds must be between " + minimum + " and " + maximum);
-        }
-    }
-
-    private static boolean isOutsideRange(int value, int minimum, int maximum) {
-        return (value > maximum || value < minimum);
-    }
-
     void validate(Webhook webhook) {
         String name = webhook.getName();
+
         if (StringUtils.isEmpty(name)) {
             throw new InvalidRequestException("{\"error\": \"Webhook name is required\"}");
         }
@@ -87,4 +76,18 @@ public class WebhookValidator {
         }
 
     }
+
+    private void isValidCallbackTimeoutSeconds(int value) {
+        int minimum = webhookProperties.getCallbackTimeoutMinimum();
+        int maximum = webhookProperties.getCallbackTimeoutMaximum();
+
+        if (isOutsideRange(value, minimum, maximum)) {
+            throw new InvalidRequestException("callbackTimeoutSeconds must be between " + minimum + " and " + maximum);
+        }
+    }
+
+    private static boolean isOutsideRange(int value, int minimum, int maximum) {
+        return (value > maximum || value < minimum);
+    }
+
 }

--- a/src/test/java/com/flightstats/hub/webhook/WebhookValidatorTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/WebhookValidatorTest.java
@@ -3,158 +3,151 @@ package com.flightstats.hub.webhook;
 import com.flightstats.hub.config.properties.AppProperties;
 import com.flightstats.hub.config.properties.WebhookProperties;
 import com.flightstats.hub.exception.InvalidRequestException;
+import com.flightstats.hub.model.WebhookType;
 import com.google.common.base.Strings;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class WebhookValidatorTest {
 
     private static final int CALLBACK_TIMEOUT_DEFAULT_IN_SEC = 120;
-
-    @Mock
-    private AppProperties appProperties;
-    @Mock
-    private WebhookProperties webhookProperties;
-    private WebhookValidator webhookValidator;
-    private Webhook webhook;
-
-    @BeforeEach
-    void setUp() {
-        webhookValidator = new WebhookValidator(appProperties, webhookProperties);
-        webhook = Webhook.builder()
-                .callbackUrl("http://client/url")
-                .channelUrl("http://hub/channel/channelName")
-                .parallelCalls(1)
-                .build();
-    }
+    private static final int MINIMUM_CALLBACK_TIMEOUT_IN_SEC = 1;
+    private static final int MAXIMUM_CALLBACK_TIMEOUT_IN_SEC = 1800;
 
     @Test
     void testName() {
-        when(appProperties.getHubType()).thenReturn("aws");
-        when(webhookProperties.getCallbackTimeoutMinimum()).thenReturn(1);
-        when(webhookProperties.getCallbackTimeoutMaximum()).thenReturn(1800);
-        webhook = webhook.withDefaults(CALLBACK_TIMEOUT_DEFAULT_IN_SEC);
-        webhookValidator.validate(webhook.withName("aA9_-"));
+        WebhookValidator webhookValidator = new WebhookValidator(getDefaultAppProperties(), getDefaultWebhookProperties());
+        Webhook webhook = getWebhook(builder -> builder.name("aA9_-"));
+        assertDoesNotThrow(() -> webhookValidator.validate(webhook));
     }
 
     @Test
     void testNameLarge() {
-        when(appProperties.getHubType()).thenReturn("aws");
-        when(webhookProperties.getCallbackTimeoutMinimum()).thenReturn(1);
-        when(webhookProperties.getCallbackTimeoutMaximum()).thenReturn(1800);
-        webhook = webhook.withDefaults(CALLBACK_TIMEOUT_DEFAULT_IN_SEC);
-        webhookValidator.validate(webhook.withName(Strings.repeat("B", 128)));
+        WebhookValidator webhookValidator = new WebhookValidator(getDefaultAppProperties(), getDefaultWebhookProperties());
+        String almostTooLongName = Strings.repeat("B", 128);
+        Webhook webhook = getWebhook(builder -> builder.name(almostTooLongName));
+        assertDoesNotThrow(() -> webhookValidator.validate(webhook));
     }
 
     @Test
     void testNameSizeTooBig() {
-        assertThrows(InvalidRequestException.class, () -> webhookValidator.validate(webhook.withName(Strings.repeat("B", 129))));
+        WebhookValidator webhookValidator = new WebhookValidator(getDefaultAppProperties(), getDefaultWebhookProperties());
+        String tooLongName = Strings.repeat("B", 129);
+        Webhook webhook = getWebhook(builder -> builder.name(tooLongName));
+        assertThrows(InvalidRequestException.class, () -> webhookValidator.validate(webhook));
     }
 
     @Test
     void testZeroCalls() {
-        assertThrows(InvalidRequestException.class, () -> webhookValidator.validate(webhook.withParallelCalls(0)));
+        WebhookValidator webhookValidator = new WebhookValidator(getDefaultAppProperties(), getDefaultWebhookProperties());
+        Webhook webhook = getWebhook(builder -> builder.parallelCalls(0));
+        assertThrows(InvalidRequestException.class, () -> webhookValidator.validate(webhook));
     }
 
     @Test
     void testNameChars() {
-        assertThrows(InvalidRequestException.class, () -> webhookValidator.validate(webhook.withName("aA9:")));
+        WebhookValidator webhookValidator = new WebhookValidator(getDefaultAppProperties(), getDefaultWebhookProperties());
+        Webhook webhook = getWebhook(builder -> builder.name("aA9:"));
+        assertThrows(InvalidRequestException.class, () -> webhookValidator.validate(webhook));
     }
 
     @Test
     void testNonChannelUrl() {
-        assertThrows(InvalidRequestException.class, () -> webhookValidator.validate(Webhook.builder()
-                .callbackUrl("http:/client/url")
-                .channelUrl("http:\\hub/channel/channelName")
-                .parallelCalls(1)
-                .name("nothing")
-                .build()));
+        WebhookValidator webhookValidator = new WebhookValidator(getDefaultAppProperties(), getDefaultWebhookProperties());
+        Webhook webhook = getWebhook(builder -> builder.channelUrl("http:\\hub/channel/channelName"));
+        assertThrows(InvalidRequestException.class, () -> webhookValidator.validate(webhook));
     }
 
     @Test
     void testInvalidCallbackUrl() {
-        assertThrows(InvalidRequestException.class, () -> webhookValidator.validate(Webhook.builder()
-                .callbackUrl("not a url")
-                .channelUrl("http://hub/channel/channelName")
-                .parallelCalls(1)
-                .name("nothing")
-                .build()));
+        WebhookValidator webhookValidator = new WebhookValidator(getDefaultAppProperties(), getDefaultWebhookProperties());
+        Webhook webhook = getWebhook(builder -> builder.callbackUrl("not a url"));
+        assertThrows(InvalidRequestException.class, () -> webhookValidator.validate(webhook));
     }
 
     @Test
     void testInvalidChannelUrl() {
-        assertThrows(InvalidRequestException.class, () -> webhookValidator.validate(Webhook.builder()
-                .callbackUrl("http:/client/url")
-                .channelUrl("http://hub/channe/channelName")
-                .parallelCalls(1)
-                .name("testInvalidChannelUrl")
-                .build()));
+        WebhookValidator webhookValidator = new WebhookValidator(getDefaultAppProperties(), getDefaultWebhookProperties());
+        Webhook webhook = getWebhook(builder -> builder.channelUrl("http://hub/chanel/channelName"));
+        assertThrows(InvalidRequestException.class, () -> webhookValidator.validate(webhook));
     }
 
     @Test
     void testInvalidBatch() {
-        webhook = webhook.withBatch("non").withName("blah");
+        WebhookValidator webhookValidator = new WebhookValidator(getDefaultAppProperties(), getDefaultWebhookProperties());
+        Webhook webhook = getWebhook(builder -> builder.batch("non"));
         assertThrows(InvalidRequestException.class, () -> webhookValidator.validate(webhook));
     }
 
     @Test
     void testBatchLowerCase() {
-        when(appProperties.getHubType()).thenReturn("aws");
-        when(webhookProperties.getCallbackTimeoutMinimum()).thenReturn(1);
-        when(webhookProperties.getCallbackTimeoutMaximum()).thenReturn(1800);
-        webhook = webhook.withBatch("single").withCallbackTimeoutSeconds(10).withName("blah");
-        webhookValidator.validate(webhook);
-    }
-
-    @Test
-    void testValidCallbackTimeout() {
-        when(appProperties.getHubType()).thenReturn("aws");
-        when(webhookProperties.getCallbackTimeoutMinimum()).thenReturn(1);
-        when(webhookProperties.getCallbackTimeoutMaximum()).thenReturn(1800);
-        webhook = webhook.withCallbackTimeoutSeconds(1000).withBatch("SINGLE").withName("blah");
-        webhookValidator.validate(webhook);
+        WebhookValidator webhookValidator = new WebhookValidator(getDefaultAppProperties(), getDefaultWebhookProperties());
+        Webhook webhook = getWebhook(builder -> builder.batch("single"));
+        assertDoesNotThrow(() -> webhookValidator.validate(webhook));
     }
 
     @Test
     void testInvalidSingleHeartbeat() {
-        webhook = webhook.withBatch("SINGLE").withHeartbeat(true).withName("blah").withCallbackTimeoutSeconds(10);
+        WebhookValidator webhookValidator = new WebhookValidator(getDefaultAppProperties(), getDefaultWebhookProperties());
+        Webhook webhook = getWebhook(builder -> builder.batch("SINGLE").heartbeat(true));
         assertThrows(InvalidRequestException.class, () -> webhookValidator.validate(webhook));
     }
 
     @Test
     void testInvalidCallbackTimeout() {
-        when(webhookProperties.getCallbackTimeoutMinimum()).thenReturn(1);
-        when(webhookProperties.getCallbackTimeoutMaximum()).thenReturn(1800);
-        webhook = webhook.withCallbackTimeoutSeconds(10 * 1000).withBatch("SINGLE").withName("blah");
+        WebhookValidator webhookValidator = new WebhookValidator(getDefaultAppProperties(), getDefaultWebhookProperties());
+        Webhook webhook = getWebhook(builder -> builder.callbackTimeoutSeconds(MAXIMUM_CALLBACK_TIMEOUT_IN_SEC + 1));
         assertThrows(InvalidRequestException.class, () -> webhookValidator.validate(webhook));
     }
 
     @Test
     void testInvalidCallbackTimeoutZero() {
-        when(webhookProperties.getCallbackTimeoutMinimum()).thenReturn(1);
-        when(webhookProperties.getCallbackTimeoutMaximum()).thenReturn(1800);
-        webhook = webhook.withCallbackTimeoutSeconds(0).withBatch("SINGLE").withName("blah");
+        WebhookValidator webhookValidator = new WebhookValidator(getDefaultAppProperties(), getDefaultWebhookProperties());
+        Webhook webhook = getWebhook(builder -> builder.callbackTimeoutSeconds(0));
         assertThrows(InvalidRequestException.class, () -> webhookValidator.validate(webhook));
     }
 
     @Test
     void testInvalidLocalhost() {
-        webhook = Webhook.builder()
-                .callbackUrl("http:/localhost:8080/url")
-                .channelUrl("http://hub/channel/channelName")
-                .parallelCalls(1)
-                .name("testInvalidChannelUrl")
-                .batch("SINGLE")
-                .callbackTimeoutSeconds(1)
-                .build();
+        WebhookValidator webhookValidator = new WebhookValidator(getDefaultAppProperties(), getDefaultWebhookProperties());
+        Webhook webhook = getWebhook(builder -> builder.callbackUrl("http://localhost:8080/url"));
         assertThrows(InvalidRequestException.class, () -> webhookValidator.validate(webhook));
     }
 
+    private Webhook getWebhook(Function<Webhook.WebhookBuilder, Webhook.WebhookBuilder> customizations) {
+        Webhook.WebhookBuilder webhookBuilder = Webhook.builder()
+                .name("someName")
+                .callbackUrl("http://client/url")
+                .channelUrl("http://hub/channel/channelName")
+                .parallelCalls(1)
+                .batch(WebhookType.SINGLE.name())
+                .callbackTimeoutSeconds(CALLBACK_TIMEOUT_DEFAULT_IN_SEC)
+                .heartbeat(false);
+        return customizations.apply(webhookBuilder).build();
+    }
+
+    private AppProperties getDefaultAppProperties() {
+        AppProperties appProperties = mock(AppProperties.class);
+        when(appProperties.getHubType()).thenReturn("aws");
+        return appProperties;
+    }
+
+    private WebhookProperties getDefaultWebhookProperties() {
+        WebhookProperties webhookProperties = mock(WebhookProperties.class);
+        when(webhookProperties.getCallbackTimeoutMinimum()).thenReturn(MINIMUM_CALLBACK_TIMEOUT_IN_SEC);
+        when(webhookProperties.getCallbackTimeoutMaximum()).thenReturn(MAXIMUM_CALLBACK_TIMEOUT_IN_SEC);
+        return webhookProperties;
+    }
 }


### PR DESCRIPTION
I'm not sure why tests in this file were only intermittently failing, but I updated the test class to use lenient mocking, because otherwise the tests are sensitive to the order of validations. I couldn't think of a reason that ordering would be particularly important.

While I was in there, I standardized the way we set up the webhook under test. Now it'll build off a valid webhook and only override the fields with which we want to trigger the validation exception.