### PR TITLE
Add a super-basic internal endpoint to more easily get list of webhooks that nodes are leading

### DIFF
--- a/src/main/java/com/flightstats/hub/webhook/LocalWebhookManager.java
+++ b/src/main/java/com/flightstats/hub/webhook/LocalWebhookManager.java
@@ -12,7 +12,9 @@ import de.jkeylockmanager.manager.KeyLockManager;
 import de.jkeylockmanager.manager.KeyLockManagers;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -107,5 +109,9 @@ public class LocalWebhookManager {
 
     int getCount() {
         return localLeaders.size();
+    }
+
+    List<String> getRunning() {
+        return new ArrayList<>(localLeaders.keySet());
     }
 }


### PR DESCRIPTION
One of the longstanding problems that we've had with webhooks is that sometimes rolling restarts cause multiple nodes to run/lead the same webhook. That causes webhooks to send duplicate items, which is annoying to debug right now.

It's not elegant, but this introduces a debug endpoint which proxies to a random node and returns the webhooks running there. Refreshing a webpage and doing a search seems easier than sshing into some servers and grepping their logs. If this ends up being useful but still kind of a pain, we can do something more robust that returns webhook info for all nodes + ZK state in a single request.

- Endpoint: `/internal/webhook/running` 
- Sample output: `{ "hub-01": ["webhook1", "webhook2"] }`
- Potential improved output somewhere down the road: `[ { "webhook": "webhookName", "leaders": ["hub-01", "hub-02"], "zk_state": ["hub-01"] } ]`

This was helpful in debugging a different webhook issue, but it's not tested because there are no existing Java tests for our web resources. Getting that set up seemed like a lot of work when I was in the middle of something else. I'm ok with having this declined because of that, but figured I'd see if its usefulness in debugging production bugs seemed to outweigh the new tech debt.