### PR TITLE
Rename some webhook classes

### DIFF
--- a/src/main/java/com/flightstats/hub/config/binding/HubBindings.java
+++ b/src/main/java/com/flightstats/hub/config/binding/HubBindings.java
@@ -1,7 +1,6 @@
 package com.flightstats.hub.config.binding;
 
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.ScheduledReporter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -33,8 +32,6 @@ import com.flightstats.hub.dao.aws.s3Verifier.VerifierConfigProvider;
 import com.flightstats.hub.events.EventsService;
 import com.flightstats.hub.health.HubHealthCheck;
 import com.flightstats.hub.metrics.CustomMetricsLifecycle;
-import com.flightstats.hub.metrics.InfluxdbReporterLifecycle;
-import com.flightstats.hub.metrics.InfluxdbReporterProvider;
 import com.flightstats.hub.metrics.MetricRegistryProvider;
 import com.flightstats.hub.metrics.StatsDFilter;
 import com.flightstats.hub.metrics.StatsDReporterLifecycle;
@@ -67,7 +64,7 @@ import com.flightstats.hub.time.TimeService;
 import com.flightstats.hub.util.HubUtils;
 import com.flightstats.hub.util.SecretFilter;
 import com.flightstats.hub.util.StaleEntity;
-import com.flightstats.hub.webhook.WebhookManager;
+import com.flightstats.hub.webhook.WebhookCoordinator;
 import com.flightstats.hub.webhook.WebhookValidator;
 import com.flightstats.hub.ws.WebSocketService;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -306,7 +303,7 @@ public class HubBindings extends AbstractModule {
 
         bind(ReplicationManager.class).asEagerSingleton();
         bind(WatchManager.class).asEagerSingleton();
-        bind(WebhookManager.class).asEagerSingleton();
+        bind(WebhookCoordinator.class).asEagerSingleton();
         bind(SpokeManager.class).asEagerSingleton();
         bind(ShutdownManager.class).asEagerSingleton();
 

--- a/src/main/java/com/flightstats/hub/webhook/InternalWebhookResource.java
+++ b/src/main/java/com/flightstats/hub/webhook/InternalWebhookResource.java
@@ -40,9 +40,10 @@ public class InternalWebhookResource {
     private final PermissionsChecker permissionsChecker;
     private final LocalHostProperties localHostProperties;
     private final WebhookService webhookService;
-    private final LocalWebhookManager localWebhookManager;
+    private final LocalWebhookRunner localWebhookRunner;
     private final StaleEntity staleEntity;
     private final ObjectMapper objectMapper;
+
 
     @Context
     private UriInfo uriInfo;
@@ -51,13 +52,13 @@ public class InternalWebhookResource {
     public InternalWebhookResource(PermissionsChecker permissionsChecker,
                                    LocalHostProperties localHostProperties,
                                    WebhookService webhookService,
-                                   LocalWebhookManager localWebhookManager,
+                                   LocalWebhookRunner localWebhookRunner,
                                    StaleEntity staleEntity,
                                    ObjectMapper objectMapper) {
         this.permissionsChecker = permissionsChecker;
         this.localHostProperties = localHostProperties;
         this.webhookService = webhookService;
-        this.localWebhookManager = localWebhookManager;
+        this.localWebhookRunner = localWebhookRunner;
         this.staleEntity = staleEntity;
         this.objectMapper = objectMapper;
     }
@@ -179,7 +180,7 @@ public class InternalWebhookResource {
     @GET
     @Path("/count")
     public Response count() {
-        return Response.ok(localWebhookManager.getCount()).build();
+        return Response.ok(localWebhookRunner.getCount()).build();
     }
 
     @GET
@@ -188,20 +189,20 @@ public class InternalWebhookResource {
     public Response running() {
         ObjectNode root = objectMapper.createObjectNode();
         ArrayNode arrayNode = root.putArray(localHostProperties.getName());
-        localWebhookManager.getRunning().forEach(arrayNode::add);
+        localWebhookRunner.getRunning().forEach(arrayNode::add);
 
         return Response.ok(root).build();
     }
 
     private Response attemptRun(String name) {
-        if (localWebhookManager.ensureRunning(name)) {
+        if (localWebhookRunner.ensureRunning(name)) {
             return Response.ok().build();
         }
         return Response.status(400).build();
     }
 
     private Response attemptDelete(String name) {
-        localWebhookManager.stopLocal(name, true);
+        localWebhookRunner.stop(name, true);
         return Response.ok().build();
     }
 

--- a/src/main/java/com/flightstats/hub/webhook/LocalWebhookRunner.java
+++ b/src/main/java/com/flightstats/hub/webhook/LocalWebhookRunner.java
@@ -24,27 +24,27 @@ import java.util.function.Consumer;
 
 @Singleton
 @Slf4j
-public class LocalWebhookManager {
+public class LocalWebhookRunner {
 
     private final Map<String, WebhookLeader> localLeaders = new ConcurrentHashMap<>();
 
     private final Dao<Webhook> webhookDao;
-    private final Provider<WebhookLeader> v2Provider;
+    private final Provider<WebhookLeader> webhookLeaderProvider;
     private final KeyLockManager lockManager;
     private final int shutdownThreadCount;
 
     @Inject
-    public LocalWebhookManager(@Named("Webhook") Dao<Webhook> webhookDao,
-                               Provider<WebhookLeader> v2Provider,
-                               WebhookProperties webhookProperties) {
+    public LocalWebhookRunner(@Named("Webhook") Dao<Webhook> webhookDao,
+                              Provider<WebhookLeader> webhookLeaderProvider,
+                              WebhookProperties webhookProperties) {
         this.webhookDao = webhookDao;
-        this.v2Provider = v2Provider;
+        this.webhookLeaderProvider = webhookLeaderProvider;
         this.lockManager = KeyLockManagers.newLock(1, TimeUnit.SECONDS);
         this.shutdownThreadCount = webhookProperties.getShutdownThreadCount();
     }
 
     public void runAndWait(String name, Collection<String> keys, Consumer<String> consumer) {
-        final ExecutorService pool = Executors.newFixedThreadPool(shutdownThreadCount,
+        ExecutorService pool = Executors.newFixedThreadPool(shutdownThreadCount,
                 new ThreadFactoryBuilder().setNameFormat(name + "-%d").build());
         log.debug("processing {}", keys);
         for (String key : keys) {
@@ -55,7 +55,7 @@ public class LocalWebhookManager {
         log.info("accepted all keys");
         pool.shutdown();
         try {
-            final boolean awaitTermination = pool.awaitTermination(5, TimeUnit.MINUTES);
+            boolean awaitTermination = pool.awaitTermination(5, TimeUnit.MINUTES);
             log.debug("awaitTermination {}", awaitTermination);
         } catch (InterruptedException e) {
             log.warn("interrupted", e);
@@ -68,37 +68,37 @@ public class LocalWebhookManager {
     }
 
     private boolean ensureRunningWithLock(String name) {
-        final Webhook daoWebhook = webhookDao.get(name);
+        Webhook daoWebhook = webhookDao.get(name);
         log.debug("ensureRunning {}", daoWebhook);
         if (localLeaders.containsKey(name)) {
             log.debug("checking for change {}", name);
-            final WebhookLeader webhookLeader = localLeaders.get(name);
-            final Webhook runningWebhook = webhookLeader.getWebhook();
+            WebhookLeader webhookLeader = localLeaders.get(name);
+            Webhook runningWebhook = webhookLeader.getWebhook();
             if (webhookLeader.hasLeadership() && !runningWebhook.isChanged(daoWebhook)) {
                 log.trace("webhook unchanged {} to {}", runningWebhook, daoWebhook);
                 return true;
             }
             log.info("webhook has changed {} to {}; stopping", runningWebhook, daoWebhook);
-            stopLocal(name, false);
+            stop(name, false);
         }
         log.info("starting {}", name);
-        return startLocal(daoWebhook);
+        return start(daoWebhook);
     }
 
-    private boolean startLocal(Webhook daoWebhook) {
-        final WebhookLeader webhookLeader = v2Provider.get();
-        final boolean hasLeadership = webhookLeader.tryLeadership(daoWebhook);
+    private boolean start(Webhook daoWebhook) {
+        WebhookLeader webhookLeader = webhookLeaderProvider.get();
+        boolean hasLeadership = webhookLeader.tryLeadership(daoWebhook);
         if (hasLeadership) {
             localLeaders.put(daoWebhook.getName(), webhookLeader);
         }
         return hasLeadership;
     }
 
-    void stopAllLocal() {
-        runAndWait("LocalWebhookManager.stopAll", localLeaders.keySet(), (name) -> stopLocal(name, false));
+    void stopAll() {
+        runAndWait("LocalWebhookRunner.stopAll", localLeaders.keySet(), (name) -> stop(name, false));
     }
 
-    void stopLocal(String name, boolean delete) {
+    void stop(String name, boolean delete) {
         log.info("stop {} {}", name, delete);
         if (localLeaders.containsKey(name)) {
             log.info("stopping local {}", name);

--- a/src/main/java/com/flightstats/hub/webhook/WebhookContentInFlight.java
+++ b/src/main/java/com/flightstats/hub/webhook/WebhookContentInFlight.java
@@ -8,13 +8,13 @@ import java.util.Set;
 
 import static java.util.stream.Collectors.toSet;
 
-class WebhookContentPathSet {
+class WebhookContentInFlight {
     private final static String BASE_PATH = "/GroupInFlight";
 
     private final SafeZooKeeperUtils zooKeeperUtils;
 
     @Inject
-    public WebhookContentPathSet(SafeZooKeeperUtils zooKeeperUtils) {
+    public WebhookContentInFlight(SafeZooKeeperUtils zooKeeperUtils) {
         this.zooKeeperUtils = zooKeeperUtils;
     }
 

--- a/src/main/java/com/flightstats/hub/webhook/WebhookCoordinator.java
+++ b/src/main/java/com/flightstats/hub/webhook/WebhookCoordinator.java
@@ -32,7 +32,7 @@ public class WebhookCoordinator {
 
     private final LocalWebhookRunner localWebhookRunner;
     private final WebhookErrorService webhookErrorService;
-    private final WebhookContentPathSet webhookContentPathSet;
+    private final WebhookContentInFlight contentKeysInFlight;
     private final InternalWebhookClient webhookClient;
     private final WebhookStateReaper webhookStateReaper;
     private final ClusterCacheDao clusterCacheDao;
@@ -43,7 +43,7 @@ public class WebhookCoordinator {
     @Inject
     public WebhookCoordinator(LocalWebhookRunner localWebhookRunner,
                               WebhookErrorService webhookErrorService,
-                              WebhookContentPathSet webhookContentPathSet,
+                              WebhookContentInFlight contentKeysInFlight,
                               InternalWebhookClient webhookClient,
                               WebhookStateReaper webhookStateReaper,
                               ClusterCacheDao clusterCacheDao,
@@ -53,7 +53,7 @@ public class WebhookCoordinator {
                               @Named("Webhook") Dao<Webhook> webhookDao) {
         this.localWebhookRunner = localWebhookRunner;
         this.webhookErrorService = webhookErrorService;
-        this.webhookContentPathSet = webhookContentPathSet;
+        this.contentKeysInFlight = contentKeysInFlight;
         this.webhookClient = webhookClient;
         this.webhookStateReaper = webhookStateReaper;
         this.clusterCacheDao = clusterCacheDao;
@@ -136,8 +136,8 @@ public class WebhookCoordinator {
         statusBuilder.lastCompleted(clusterCacheDao.get(webhook.getName(), WebhookStrategy.createContentPath(webhook), WEBHOOK_LAST_COMPLETED));
         try {
             statusBuilder.errors(webhookErrorService.lookup(webhook.getName()));
-            ArrayList<ContentPath> inFlight = new ArrayList<>(new TreeSet<>(webhookContentPathSet.getSet(webhook.getName(), WebhookStrategy.createContentPath(webhook))));
-            statusBuilder.inFlight(inFlight);
+            ArrayList<ContentPath> contentInFlight = new ArrayList<>(new TreeSet<>(contentKeysInFlight.getSet(webhook.getName(), WebhookStrategy.createContentPath(webhook))));
+            statusBuilder.inFlight(contentInFlight);
         } catch (Exception e) {
             log.warn("unable to get status {}", webhook.getName(), e);
             statusBuilder.errors(Collections.emptyList());

--- a/src/main/java/com/flightstats/hub/webhook/WebhookCoordinator.java
+++ b/src/main/java/com/flightstats/hub/webhook/WebhookCoordinator.java
@@ -18,9 +18,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 
@@ -29,10 +27,10 @@ import static com.flightstats.hub.constant.ZookeeperNodes.WEBHOOK_LAST_COMPLETED
 
 @Slf4j
 @Singleton
-public class WebhookManager {
+public class WebhookCoordinator {
     private static final String WATCHER_PATH = "/groupCallback/watcher";
 
-    private final LocalWebhookManager localWebhookManager;
+    private final LocalWebhookRunner localWebhookRunner;
     private final WebhookErrorService webhookErrorService;
     private final WebhookContentPathSet webhookContentPathSet;
     private final InternalWebhookClient webhookClient;
@@ -43,17 +41,17 @@ public class WebhookManager {
     private final Dao<Webhook> webhookDao;
 
     @Inject
-    public WebhookManager(LocalWebhookManager localWebhookManager,
-                          WebhookErrorService webhookErrorService,
-                          WebhookContentPathSet webhookContentPathSet,
-                          InternalWebhookClient webhookClient,
-                          WebhookStateReaper webhookStateReaper,
-                          ClusterCacheDao clusterCacheDao,
-                          ActiveWebhooks activeWebhooks,
-                          WebhookProperties webhookProperties,
-                          WatchManager watchManager,
-                          @Named("Webhook") Dao<Webhook> webhookDao) {
-        this.localWebhookManager = localWebhookManager;
+    public WebhookCoordinator(LocalWebhookRunner localWebhookRunner,
+                              WebhookErrorService webhookErrorService,
+                              WebhookContentPathSet webhookContentPathSet,
+                              InternalWebhookClient webhookClient,
+                              WebhookStateReaper webhookStateReaper,
+                              ClusterCacheDao clusterCacheDao,
+                              ActiveWebhooks activeWebhooks,
+                              WebhookProperties webhookProperties,
+                              WatchManager watchManager,
+                              @Named("Webhook") Dao<Webhook> webhookDao) {
+        this.localWebhookRunner = localWebhookRunner;
         this.webhookErrorService = webhookErrorService;
         this.webhookContentPathSet = webhookContentPathSet;
         this.webhookClient = webhookClient;
@@ -64,8 +62,8 @@ public class WebhookManager {
         this.webhookDao = webhookDao;
 
         if (webhookProperties.isWebhookLeadershipEnabled()) {
-            register(new WebhookIdleService(), HubServices.TYPE.AFTER_HEALTHY_START, HubServices.TYPE.PRE_STOP);
-            register(new WebhookScheduledService(), HubServices.TYPE.AFTER_HEALTHY_START);
+            register(new WebhookCoordinatorIdleService(), HubServices.TYPE.AFTER_HEALTHY_START, HubServices.TYPE.PRE_STOP);
+            register(new WebhookCoordinatorScheduledService(), HubServices.TYPE.AFTER_HEALTHY_START);
         }
     }
 
@@ -73,7 +71,7 @@ public class WebhookManager {
         watchManager.register(new Watcher() {
             @Override
             public void callback(CuratorEvent event) {
-                manageWebhooks(true);
+                manageWebhookLeaders(true);
             }
 
             @Override
@@ -82,20 +80,20 @@ public class WebhookManager {
             }
 
         });
-        manageWebhooks(false);
+        manageWebhookLeaders(false);
     }
 
-    private synchronized void manageWebhooks(boolean useCache) {
+    private synchronized void manageWebhookLeaders(boolean useCache) {
         webhookDao.getAll(useCache)
-                .forEach(webhook -> manageWebhook(webhook, false));
+                .forEach(webhook -> ensureRunningOnOnlyOneServer(webhook, false));
     }
 
     void notifyWatchers(Webhook webhook) {
-        manageWebhook(webhook, true);
+        ensureRunningOnOnlyOneServer(webhook, true);
     }
 
     @VisibleForTesting
-    void manageWebhook(Webhook daoWebhook, boolean webhookChanged) {
+    void ensureRunningOnOnlyOneServer(Webhook daoWebhook, boolean webhookChanged) {
         if (daoWebhook.getTagUrl() != null && !daoWebhook.getTagUrl().isEmpty()) {
             // tag webhooks are not processed like normal webhooks.
             // they are used as prototype definitions for new webhooks added
@@ -129,7 +127,7 @@ public class WebhookManager {
         watchManager.notifyWatcher(WATCHER_PATH);
     }
 
-    public void delete(String name) {
+    public void stopLeader(String name) {
         webhookClient.remove(name, activeWebhooks.getServers(name));
         webhookStateReaper.delete(name);
     }
@@ -147,7 +145,7 @@ public class WebhookManager {
         }
     }
 
-    private class WebhookIdleService extends AbstractIdleService {
+    private class WebhookCoordinatorIdleService extends AbstractIdleService {
 
         @Override
         protected void startUp() {
@@ -156,16 +154,16 @@ public class WebhookManager {
 
         @Override
         protected void shutDown() {
-            localWebhookManager.stopAllLocal();
+            localWebhookRunner.stopAll();
             notifyWatchers();
         }
 
     }
 
-    private class WebhookScheduledService extends AbstractScheduledService {
+    private class WebhookCoordinatorScheduledService extends AbstractScheduledService {
         @Override
         protected void runOneIteration() {
-            manageWebhooks(false);
+            manageWebhookLeaders(false);
         }
 
         @Override

--- a/src/main/java/com/flightstats/hub/webhook/WebhookManager.java
+++ b/src/main/java/com/flightstats/hub/webhook/WebhookManager.java
@@ -86,10 +86,8 @@ public class WebhookManager {
     }
 
     private synchronized void manageWebhooks(boolean useCache) {
-        final Set<Webhook> daoWebhooks = new HashSet<>(webhookDao.getAll(useCache));
-        for (Webhook daoWebhook : daoWebhooks) {
-            manageWebhook(daoWebhook, false);
-        }
+        webhookDao.getAll(useCache)
+                .forEach(webhook -> manageWebhook(webhook, false));
     }
 
     void notifyWatchers(Webhook webhook) {
@@ -105,12 +103,12 @@ public class WebhookManager {
             // associated with a tag webhook
             return;
         }
-        final String name = daoWebhook.getName();
+        String name = daoWebhook.getName();
         if (activeWebhooks.isActiveWebhook(name)) {
             log.debug("found existing webhook {}", name);
-            final List<String> servers = new ArrayList<>(activeWebhooks.getServers(name));
+            List<String> servers = new ArrayList<>(activeWebhooks.getServers(name));
             if (servers.size() >= 2) {
-                log.warn("found multiple servers! {}", servers);
+                log.warn("found multiple servers leading {}! {}", name, servers);
                 Collections.shuffle(servers);
                 for (int i = 1; i < servers.size(); i++) {
                     webhookClient.remove(name, servers.get(i));
@@ -140,7 +138,7 @@ public class WebhookManager {
         statusBuilder.lastCompleted(clusterCacheDao.get(webhook.getName(), WebhookStrategy.createContentPath(webhook), WEBHOOK_LAST_COMPLETED));
         try {
             statusBuilder.errors(webhookErrorService.lookup(webhook.getName()));
-            final ArrayList<ContentPath> inFlight = new ArrayList<>(new TreeSet<>(webhookContentPathSet.getSet(webhook.getName(), WebhookStrategy.createContentPath(webhook))));
+            ArrayList<ContentPath> inFlight = new ArrayList<>(new TreeSet<>(webhookContentPathSet.getSet(webhook.getName(), WebhookStrategy.createContentPath(webhook))));
             statusBuilder.inFlight(inFlight);
         } catch (Exception e) {
             log.warn("unable to get status {}", webhook.getName(), e);

--- a/src/main/java/com/flightstats/hub/webhook/WebhookService.java
+++ b/src/main/java/com/flightstats/hub/webhook/WebhookService.java
@@ -37,7 +37,7 @@ public class WebhookService {
     private final ClusterCacheDao clusterCacheDao;
     private final ChannelService channelService;
     private final ContentRetriever contentRetriever;
-    private final LocalWebhookManager localWebhookManager;
+    private final LocalWebhookRunner localWebhookRunner;
     private final WebhookProperties webhookProperties;
 
     @Inject
@@ -47,7 +47,7 @@ public class WebhookService {
                           ClusterCacheDao clusterCacheDao,
                           ChannelService channelService,
                           ContentRetriever contentRetriever,
-                          LocalWebhookManager localWebhookManager,
+                          LocalWebhookRunner localWebhookRunner,
                           WebhookProperties webhookProperties) {
         this.webhookDao = webhookDao;
         this.webhookValidator = webhookValidator;
@@ -55,7 +55,7 @@ public class WebhookService {
         this.clusterCacheDao = clusterCacheDao;
         this.channelService = channelService;
         this.contentRetriever = contentRetriever;
-        this.localWebhookManager = localWebhookManager;
+        this.localWebhookRunner = localWebhookRunner;
         this.webhookProperties = webhookProperties;
     }
 
@@ -172,7 +172,7 @@ public class WebhookService {
                 .map((Webhook::getName))
                 .collect(Collectors.toSet());
 
-        localWebhookManager.runAndWait("TagWebhook.deleteAll", names, this::delete);
+        localWebhookRunner.runAndWait("TagWebhook.deleteAll", names, this::delete);
     }
 
     // Add new wh instances for new or updated tag webhook

--- a/src/main/java/com/flightstats/hub/webhook/WebhookStateReaper.java
+++ b/src/main/java/com/flightstats/hub/webhook/WebhookStateReaper.java
@@ -13,19 +13,19 @@ import static com.flightstats.hub.constant.ZookeeperNodes.WEBHOOK_LAST_COMPLETED
 @Slf4j
 class WebhookStateReaper {
     private final ClusterCacheDao clusterCacheDao;
-    private final WebhookContentPathSet webhookInProcess;
+    private final WebhookContentInFlight contentKeysInFlight;
     private final WebhookErrorService webhookErrorService;
     private final WebhookLeaderLocks webhookLeaderLocks;
     private final WebhookProperties webhookProperties;
 
     @Inject
     WebhookStateReaper(ClusterCacheDao clusterCacheDao,
-                       WebhookContentPathSet webhookInProcess,
+                       WebhookContentInFlight contentKeysInFlight,
                        WebhookErrorService webhookErrorService,
                        WebhookLeaderLocks webhookLeaderLocks,
                        WebhookProperties webhookProperties) {
         this.clusterCacheDao = clusterCacheDao;
-        this.webhookInProcess = webhookInProcess;
+        this.contentKeysInFlight = contentKeysInFlight;
         this.webhookErrorService = webhookErrorService;
         this.webhookLeaderLocks = webhookLeaderLocks;
         this.webhookProperties = webhookProperties;
@@ -36,7 +36,7 @@ class WebhookStateReaper {
             return;
         }
         log.debug("deleting {}", webhook);
-        webhookInProcess.delete(webhook);
+        contentKeysInFlight.delete(webhook);
         clusterCacheDao.delete(webhook, WEBHOOK_LAST_COMPLETED);
         webhookErrorService.delete(webhook);
         webhookLeaderLocks.deleteWebhookLeader(webhook);

--- a/src/test/java/com/flightstats/hub/webhook/WebhookContentInFlightTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/WebhookContentInFlightTest.java
@@ -14,9 +14,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class WebhookContentPathSetTest {
+class WebhookContentInFlightTest {
     private SafeZooKeeperUtils zooKeeperUtils;
-    private WebhookContentPathSet groupSet;
+    private WebhookContentInFlight keysInFlight;
     private String groupName;
 
     @BeforeEach
@@ -27,7 +27,7 @@ class WebhookContentPathSetTest {
 
     @Test
     void testLifecycle() throws Exception {
-        groupSet = new WebhookContentPathSet(zooKeeperUtils);
+        keysInFlight = new WebhookContentInFlight(zooKeeperUtils);
         ContentKey first = new ContentKey();
         ContentKey second = new ContentKey();
         ContentKey third = new ContentKey();
@@ -41,29 +41,29 @@ class WebhookContentPathSetTest {
     }
 
     private void removeAndCompare(ContentKey key, int expected) {
-        groupSet.remove(groupName, key);
-        Set<ContentPath> set = groupSet.getSet(groupName, key);
+        keysInFlight.remove(groupName, key);
+        Set<ContentPath> set = keysInFlight.getSet(groupName, key);
         assertEquals(expected, set.size());
         assertFalse(set.contains(key));
     }
 
     private void addAndCompare(ContentKey key, int expected) {
-        groupSet.add(groupName, key);
-        Set<ContentPath> set = groupSet.getSet(groupName, key);
+        keysInFlight.add(groupName, key);
+        Set<ContentPath> set = keysInFlight.getSet(groupName, key);
         assertEquals(expected, set.size());
         assertTrue(set.contains(key));
     }
 
     @Test
     void testDelete() throws Exception {
-        groupSet = new WebhookContentPathSet(zooKeeperUtils);
+        keysInFlight = new WebhookContentInFlight(zooKeeperUtils);
         groupName = "testDelete";
         ContentKey contentKey = new ContentKey();
         addAndCompare(contentKey, 1);
         addAndCompare(new ContentKey(), 2);
         addAndCompare(new ContentKey(), 3);
-        groupSet.delete(groupName);
-        assertEquals(0, groupSet.getSet(groupName, contentKey).size());
+        keysInFlight.delete(groupName);
+        assertEquals(0, keysInFlight.getSet(groupName, contentKey).size());
 
     }
 

--- a/src/test/java/com/flightstats/hub/webhook/WebhookCoordinatorTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/WebhookCoordinatorTest.java
@@ -45,7 +45,7 @@ class WebhookCoordinatorTest {
     @Mock
     private WebhookErrorService webhookErrorService;
     @Mock
-    private WebhookContentPathSet webhookContentPathSet;
+    private WebhookContentInFlight keysInFlight;
     @Mock
     private InternalWebhookClient webhookClient;
     @Mock
@@ -205,7 +205,7 @@ class WebhookCoordinatorTest {
         return new WebhookCoordinator(
                 localWebhookRunner,
                 webhookErrorService,
-                webhookContentPathSet,
+                keysInFlight,
                 webhookClient,
                 webhookStateReaper,
                 clusterCacheDao,

--- a/src/test/java/com/flightstats/hub/webhook/WebhookCoordinatorTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/WebhookCoordinatorTest.java
@@ -80,7 +80,7 @@ class WebhookCoordinatorTest {
         when(activeWebhooks.isActiveWebhook(WEBHOOK_NAME)).thenReturn(true);
         when(activeWebhooks.getServers(WEBHOOK_NAME)).thenReturn(newHashSet("hub-01"));
 
-        WebhookCoordinator webhookCoordinator = getWebhookManager();
+        WebhookCoordinator webhookCoordinator = getWebhookCoordinator();
         webhookCoordinator.ensureRunningOnOnlyOneServer(Webhook.builder().name(WEBHOOK_NAME).build(), false);
 
         verify(webhookClient, never()).runOnServerWithFewestWebhooks(WEBHOOK_NAME);
@@ -96,7 +96,7 @@ class WebhookCoordinatorTest {
 
         when(webhookClient.runOnServerWithFewestWebhooks(WEBHOOK_NAME)).thenReturn(Optional.of(SERVER1));
 
-        WebhookCoordinator webhookCoordinator = getWebhookManager();
+        WebhookCoordinator webhookCoordinator = getWebhookCoordinator();
         webhookCoordinator.ensureRunningOnOnlyOneServer(Webhook.builder().name(WEBHOOK_NAME).build(), false);
 
         verify(webhookClient).runOnServerWithFewestWebhooks(WEBHOOK_NAME);
@@ -110,7 +110,7 @@ class WebhookCoordinatorTest {
 
         when(webhookClient.runOnServerWithFewestWebhooks(WEBHOOK_NAME)).thenReturn(Optional.of(SERVER1));
 
-        WebhookCoordinator webhookCoordinator = getWebhookManager();
+        WebhookCoordinator webhookCoordinator = getWebhookCoordinator();
         webhookCoordinator.ensureRunningOnOnlyOneServer(Webhook.builder().name(WEBHOOK_NAME).build(), false);
 
         verify(webhookClient).runOnServerWithFewestWebhooks(WEBHOOK_NAME);
@@ -127,7 +127,7 @@ class WebhookCoordinatorTest {
         when(webhookClient.remove(WEBHOOK_NAME, SERVER2)).thenReturn(true);
         when(webhookClient.remove(WEBHOOK_NAME, SERVER3)).thenReturn(true);
 
-        WebhookCoordinator webhookCoordinator = getWebhookManager();
+        WebhookCoordinator webhookCoordinator = getWebhookCoordinator();
         webhookCoordinator.ensureRunningOnOnlyOneServer(Webhook.builder().name(WEBHOOK_NAME).build(), false);
 
         verify(webhookClient, times(2)).remove(eq(WEBHOOK_NAME), matches(
@@ -142,7 +142,7 @@ class WebhookCoordinatorTest {
         when(activeWebhooks.getServers(WEBHOOK_NAME)).thenReturn(newHashSet(SERVER1));
         when(webhookClient.runOnOneServer(WEBHOOK_NAME, newArrayList(SERVER1))).thenReturn(Optional.of(SERVER1));
 
-        WebhookCoordinator webhookCoordinator = getWebhookManager();
+        WebhookCoordinator webhookCoordinator = getWebhookCoordinator();
         webhookCoordinator.ensureRunningOnOnlyOneServer(Webhook.builder().name(WEBHOOK_NAME).build(), true);
 
         verify(webhookClient).runOnOneServer(WEBHOOK_NAME, newArrayList(SERVER1));
@@ -161,7 +161,7 @@ class WebhookCoordinatorTest {
         when(webhookClient.remove(WEBHOOK_NAME, SERVER2)).thenReturn(true);
         when(webhookClient.remove(WEBHOOK_NAME, SERVER3)).thenReturn(true);
 
-        WebhookCoordinator webhookCoordinator = getWebhookManager();
+        WebhookCoordinator webhookCoordinator = getWebhookCoordinator();
         webhookCoordinator.ensureRunningOnOnlyOneServer(Webhook.builder().name(WEBHOOK_NAME).build(), true);
 
         verify(webhookClient, times(2)).remove(eq(WEBHOOK_NAME), matches(
@@ -176,7 +176,7 @@ class WebhookCoordinatorTest {
                 .tagUrl("http://some.tag")
                 .build();
 
-        WebhookCoordinator webhookCoordinator = getWebhookManager();
+        WebhookCoordinator webhookCoordinator = getWebhookCoordinator();
         webhookCoordinator.ensureRunningOnOnlyOneServer(tagWebhook, false);
 
         verify(activeWebhooks, never()).isActiveWebhook(anyString());
@@ -187,7 +187,7 @@ class WebhookCoordinatorTest {
 
     @Test
     void testRegistersServices() {
-        getWebhookManager();
+        getWebhookCoordinator();
         Map<HubServices.TYPE, List<Service>> services = HubServices.getServices();
         assertEquals(2, services.get(HubServices.TYPE.AFTER_HEALTHY_START).size());
         assertEquals(1, services.get(HubServices.TYPE.PRE_STOP).size());
@@ -196,12 +196,12 @@ class WebhookCoordinatorTest {
     @Test
     void testIfNotLeaderWontRegisterServices() {
         when(webhookProperties.isWebhookLeadershipEnabled()).thenReturn(false);
-        getWebhookManager();
+        getWebhookCoordinator();
         Map<HubServices.TYPE, List<Service>> services = HubServices.getServices();
         services.forEach((type, svcs) -> assertTrue(type + " has services registered", svcs.isEmpty()));
     }
 
-    private WebhookCoordinator getWebhookManager() {
+    private WebhookCoordinator getWebhookCoordinator() {
         return new WebhookCoordinator(
                 localWebhookRunner,
                 webhookErrorService,

--- a/src/test/java/com/flightstats/hub/webhook/WebhookStateReaperTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/WebhookStateReaperTest.java
@@ -42,7 +42,7 @@ class WebhookStateReaperTest {
 
     private CuratorFramework curator;
     private ClusterCacheDao clusterCacheDao;
-    private WebhookContentPathSet webhookInProcess;
+    private WebhookContentInFlight contentKeysInFlight;
     private WebhookErrorService webhookErrorService;
     private WebhookLeaderLocks webhookLeaderLocks;
     @Mock
@@ -67,7 +67,7 @@ class WebhookStateReaperTest {
         webhookLeaderLocks = new WebhookLeaderLocks(zooKeeperUtils);
         clusterCacheDao = new ClusterCacheDao(curator, appProperties);
         webhookErrorService = new WebhookErrorService(webhookErrorRepository, webhookErrorPruner, channelService);
-        webhookInProcess = new WebhookContentPathSet(zooKeeperUtils);
+        contentKeysInFlight = new WebhookContentInFlight(zooKeeperUtils);
     }
 
     @Test
@@ -79,7 +79,7 @@ class WebhookStateReaperTest {
         addWebhookLeader(webhookName);
 
         // WHEN
-        WebhookStateReaper reaper = new WebhookStateReaper(clusterCacheDao, webhookInProcess, webhookErrorService, webhookLeaderLocks, webhookProperties);
+        WebhookStateReaper reaper = new WebhookStateReaper(clusterCacheDao, contentKeysInFlight, webhookErrorService, webhookLeaderLocks, webhookProperties);
         reaper.delete(webhookName);
 
         // THEN
@@ -97,7 +97,7 @@ class WebhookStateReaperTest {
         addWebhookLeader(webhookName);
 
         // WHEN
-        WebhookStateReaper reaper = new WebhookStateReaper(clusterCacheDao, webhookInProcess, webhookErrorService, webhookLeaderLocks, webhookProperties);
+        WebhookStateReaper reaper = new WebhookStateReaper(clusterCacheDao, contentKeysInFlight, webhookErrorService, webhookLeaderLocks, webhookProperties);
         reaper.delete(webhookName);
 
         // THEN
@@ -115,7 +115,7 @@ class WebhookStateReaperTest {
         addWebhookLeader(webhookName);
 
         // WHEN
-        WebhookStateReaper reaper = new WebhookStateReaper(clusterCacheDao, webhookInProcess, webhookErrorService, webhookLeaderLocks, webhookProperties);
+        WebhookStateReaper reaper = new WebhookStateReaper(clusterCacheDao, contentKeysInFlight, webhookErrorService, webhookLeaderLocks, webhookProperties);
         reaper.delete(webhookName);
 
         // THEN
@@ -133,7 +133,7 @@ class WebhookStateReaperTest {
         addWebhookLeader(webhookName);
 
         // WHEN
-        WebhookStateReaper reaper = new WebhookStateReaper(clusterCacheDao, webhookInProcess, webhookErrorService, webhookLeaderLocks, webhookProperties);
+        WebhookStateReaper reaper = new WebhookStateReaper(clusterCacheDao, contentKeysInFlight, webhookErrorService, webhookLeaderLocks, webhookProperties);
         reaper.delete(webhookName);
 
         // THEN
@@ -151,7 +151,7 @@ class WebhookStateReaperTest {
         addError(webhookName);
 
         // WHEN
-        WebhookStateReaper reaper = new WebhookStateReaper(clusterCacheDao, webhookInProcess, webhookErrorService, webhookLeaderLocks, webhookProperties);
+        WebhookStateReaper reaper = new WebhookStateReaper(clusterCacheDao, contentKeysInFlight, webhookErrorService, webhookLeaderLocks, webhookProperties);
         reaper.delete(webhookName);
 
         // THEN
@@ -171,7 +171,7 @@ class WebhookStateReaperTest {
         addWebhookLeader(webhookName);
 
         // WHEN
-        WebhookStateReaper reaper = new WebhookStateReaper(clusterCacheDao, webhookInProcess, webhookErrorService, webhookLeaderLocks, webhookProperties);
+        WebhookStateReaper reaper = new WebhookStateReaper(clusterCacheDao, contentKeysInFlight, webhookErrorService, webhookLeaderLocks, webhookProperties);
         reaper.delete(webhookName);
 
         // THEN
@@ -182,7 +182,7 @@ class WebhookStateReaperTest {
 
         // ...AND then clean up the state so the next test can run.  Eww.
         when(webhookProperties.isWebhookLeadershipEnabled()).thenReturn(true);
-        reaper = new WebhookStateReaper(clusterCacheDao, webhookInProcess, webhookErrorService, webhookLeaderLocks, webhookProperties);
+        reaper = new WebhookStateReaper(clusterCacheDao, contentKeysInFlight, webhookErrorService, webhookLeaderLocks, webhookProperties);
         reaper.delete(webhookName);
     }
 
@@ -192,7 +192,7 @@ class WebhookStateReaperTest {
     }
 
     private void addWebhookInProcess(String webhook) {
-        webhookInProcess.add(webhook, key);
+        contentKeysInFlight.add(webhook, key);
         assertWebhookInProcessExists(webhook);
     }
 
@@ -213,7 +213,7 @@ class WebhookStateReaperTest {
     }
 
     private void assertWebhookInProcessExists(String webhook) {
-        assertEquals(1, webhookInProcess.getSet(webhook, key).size());
+        assertEquals(1, contentKeysInFlight.getSet(webhook, key).size());
     }
 
     private void assertErrorExists(String webhook) {
@@ -234,7 +234,7 @@ class WebhookStateReaperTest {
     }
 
     private void assertWebhookInProcessDeleted(String webhook) {
-        assertTrue(webhookInProcess.getSet(webhook, key).isEmpty());
+        assertTrue(contentKeysInFlight.getSet(webhook, key).isEmpty());
     }
 
     private void assertWebhookLeaderDeleted(String webhook) {


### PR DESCRIPTION
We've got a million `Webhook` classes and a million `Manager` classes. This tries to name some of them more aptly.
- `WebhookManager` is the class that's responsible for making sure that all active webhooks are running on one and only one node. `Coordinator` seemed slightly more appropriate, even if it's also an overused name.
- `LocalWebhookManager` is where webhooks are actually running, updating state, delivering items, etc. It's who we ask if we want to know what webhooks a particular node is actually leading. I dropped `Manager` for the still bad, but slightly more specific `Runner`.
- `WebhookContentPathSet` aka groupSet aka groupInFlight is now `WebhookContentInFlight` and it's ZK state of all the content keys that are currently trying to be delivered to webhook callbacks.

I'm open to better names. These made it easier for me to reason about flow for the data loss bug...