### PR TITLE
HUB-994: Don't try to start a paused webhook in our periodically-run webhook coordinator

### DIFF
--- a/src/main/java/com/flightstats/hub/dao/aws/S3BatchManager.java
+++ b/src/main/java/com/flightstats/hub/dao/aws/S3BatchManager.java
@@ -65,8 +65,9 @@ public class S3BatchManager {
                     appProperties.getAppEnv());
 
             if (channel.isSingle()) {
-                if (!webhookLeaderState.getServers(channel.getName()).isEmpty()) {
-                    log.debug("turning off batch webhook {}", channel.getDisplayName());
+                WebhookLeaderState.RunningState state = webhookLeaderState.getState(channel.getName());
+                if (!state.isStopped()) {
+                    log.debug("turning off batch webhook for {}", channel.getDisplayName());
                     s3Batch.delete();
                 }
             } else {

--- a/src/main/java/com/flightstats/hub/dao/aws/S3BatchManager.java
+++ b/src/main/java/com/flightstats/hub/dao/aws/S3BatchManager.java
@@ -7,7 +7,7 @@ import com.flightstats.hub.dao.Dao;
 import com.flightstats.hub.model.ChannelConfig;
 import com.flightstats.hub.replication.S3Batch;
 import com.flightstats.hub.util.HubUtils;
-import com.flightstats.hub.webhook.ActiveWebhooks;
+import com.flightstats.hub.webhook.WebhookLeaderState;
 import com.flightstats.hub.webhook.Webhook;
 import com.flightstats.hub.webhook.WebhookService;
 import com.google.common.util.concurrent.AbstractIdleService;
@@ -27,20 +27,20 @@ public class S3BatchManager {
     private final WebhookService webhookService;
     private final Dao<ChannelConfig> channelConfigDao;
     private final HubUtils hubUtils;
-    private final ActiveWebhooks activeWebhooks;
+    private final WebhookLeaderState webhookLeaderState;
     private final AppProperties appProperties;
 
     @Inject
     public S3BatchManager(WebhookService webhookService,
                           @Named("ChannelConfig") Dao<ChannelConfig> channelConfigDao,
                           HubUtils hubUtils,
-                          ActiveWebhooks activeWebhooks,
+                          WebhookLeaderState webhookLeaderState,
                           AppProperties appProperties,
                           S3Properties s3Properties) {
         this.webhookService = webhookService;
         this.channelConfigDao = channelConfigDao;
         this.hubUtils = hubUtils;
-        this.activeWebhooks = activeWebhooks;
+        this.webhookLeaderState = webhookLeaderState;
         this.appProperties = appProperties;
 
         if (s3Properties.isBatchManagementEnabled()) {
@@ -65,7 +65,7 @@ public class S3BatchManager {
                     appProperties.getAppEnv());
 
             if (channel.isSingle()) {
-                if (!activeWebhooks.getServers(channel.getName()).isEmpty()) {
+                if (!webhookLeaderState.getServers(channel.getName()).isEmpty()) {
                     log.debug("turning off batch webhook {}", channel.getDisplayName());
                     s3Batch.delete();
                 }

--- a/src/main/java/com/flightstats/hub/webhook/InternalWebhookClient.java
+++ b/src/main/java/com/flightstats/hub/webhook/InternalWebhookClient.java
@@ -3,7 +3,6 @@ package com.flightstats.hub.webhook;
 import com.flightstats.hub.cluster.CuratorCluster;
 import com.flightstats.hub.config.properties.LocalHostProperties;
 import com.flightstats.hub.util.HubUtils;
-import com.google.common.annotations.VisibleForTesting;
 import com.sun.jersey.api.client.Client;
 import com.sun.jersey.api.client.ClientResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -83,8 +82,7 @@ public class InternalWebhookClient {
      * We want this to return this list in order from fewest to most
      * If we get a non-200, return max int so it's tried last
      */
-    @VisibleForTesting
-    Collection<String> getOrderedServers() {
+    private Collection<String> getOrderedServers() {
         return hubCluster.getRandomServers().stream()
                 .sorted(Comparator.comparingInt(this::getCount))
                 .collect(toList());

--- a/src/main/java/com/flightstats/hub/webhook/WebhookCoordinator.java
+++ b/src/main/java/com/flightstats/hub/webhook/WebhookCoordinator.java
@@ -103,9 +103,10 @@ public class WebhookCoordinator {
             return;
         }
         String name = daoWebhook.getName();
-        if (webhookLeaderState.isActiveWebhook(name)) {
+        WebhookLeaderState.RunningState state = webhookLeaderState.getState(name);
+        if (state.isLeadershipAcquired()) {
             log.debug("found existing webhook {}", name);
-            List<String> servers = new ArrayList<>(webhookLeaderState.getServers(name));
+            List<String> servers = new ArrayList<>(state.getRunningServers());
             if (servers.size() >= 2) {
                 log.warn("found multiple servers leading {}! {}", name, servers);
                 Collections.shuffle(servers);
@@ -129,7 +130,8 @@ public class WebhookCoordinator {
     }
 
     public void stopLeader(String name) {
-        webhookClient.stop(name, webhookLeaderState.getServers(name));
+        WebhookLeaderState.RunningState state = webhookLeaderState.getState(name);
+        webhookClient.stop(name, state.getRunningServers());
         webhookStateReaper.stop(name);
     }
 

--- a/src/main/java/com/flightstats/hub/webhook/WebhookCoordinator.java
+++ b/src/main/java/com/flightstats/hub/webhook/WebhookCoordinator.java
@@ -123,7 +123,8 @@ public class WebhookCoordinator {
 
     }
 
-    private static class WebhookActionDirector {
+    @VisibleForTesting
+    static class WebhookActionDirector {
         private final WebhookLeaderState.RunningState state;
         private final boolean hasChanged;
         private final Webhook webhook;

--- a/src/main/java/com/flightstats/hub/webhook/WebhookCoordinator.java
+++ b/src/main/java/com/flightstats/hub/webhook/WebhookCoordinator.java
@@ -123,8 +123,7 @@ public class WebhookCoordinator {
 
     }
 
-    @VisibleForTesting
-    static class WebhookActionDirector {
+    private static class WebhookActionDirector {
         private final WebhookLeaderState.RunningState state;
         private final boolean hasChanged;
         private final Webhook webhook;

--- a/src/main/java/com/flightstats/hub/webhook/WebhookLeaderState.java
+++ b/src/main/java/com/flightstats/hub/webhook/WebhookLeaderState.java
@@ -10,12 +10,12 @@ import java.util.Set;
 import static java.util.stream.Collectors.toSet;
 
 @Singleton
-public class ActiveWebhooks {
+public class WebhookLeaderState {
     private final WebhookLeaderLocks webhookLeaderLocks;
     private final LocalHostProperties localHostProperties;
 
     @Inject
-    public ActiveWebhooks(
+    public WebhookLeaderState(
             WebhookLeaderLocks webhookLeaderLocks,
             ActiveWebhookSweeper activeWebhookSweeper,
             WebhookProperties webhookProperties,

--- a/src/main/java/com/flightstats/hub/webhook/WebhookLeaderState.java
+++ b/src/main/java/com/flightstats/hub/webhook/WebhookLeaderState.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Value;
 import lombok.experimental.Wither;
 
+import java.util.Collections;
 import java.util.Set;
 
 import static java.util.stream.Collectors.toSet;
@@ -53,7 +54,8 @@ public class WebhookLeaderState {
     @Value
     public static class RunningState {
         boolean leadershipAcquired;
-        Set<String> runningServers;
+        @Builder.Default
+        Set<String> runningServers = Collections.emptySet();
 
         public boolean isRunningOnSingleServer() {
             return isLeadershipAcquired() && getRunningServers().size() == 1;

--- a/src/main/java/com/flightstats/hub/webhook/WebhookLeaderState.java
+++ b/src/main/java/com/flightstats/hub/webhook/WebhookLeaderState.java
@@ -4,6 +4,9 @@ import com.flightstats.hub.config.properties.LocalHostProperties;
 import com.flightstats.hub.config.properties.WebhookProperties;
 import javax.inject.Inject;
 import com.google.inject.Singleton;
+import lombok.Builder;
+import lombok.Value;
+import lombok.experimental.Wither;
 
 import java.util.Set;
 
@@ -28,13 +31,40 @@ public class WebhookLeaderState {
         this.localHostProperties = localHostProperties;
     }
 
-    boolean isActiveWebhook(String webhookName) {
+    public RunningState getState(String webhookName) {
+        return RunningState.builder()
+                .leadershipAcquired(hasLeader(webhookName))
+                .runningServers(getServers(webhookName))
+                .build();
+    }
+
+    private boolean hasLeader(String webhookName) {
         return webhookLeaderLocks.getWebhooks().contains(webhookName);
     }
 
-    public Set<String> getServers(String name) {
+    private Set<String> getServers(String name) {
         return webhookLeaderLocks.getServerLeases(name).stream()
                 .map(server -> server + ":" + localHostProperties.getPort())
                 .collect(toSet());
+    }
+
+    @Builder
+    @Wither
+    @Value
+    public static class RunningState {
+        boolean leadershipAcquired;
+        Set<String> runningServers;
+
+        public boolean isRunningOnSingleServer() {
+            return isLeadershipAcquired() && getRunningServers().size() == 1;
+        }
+
+        public boolean isStopped() {
+            return !isLeadershipAcquired() && getRunningServers().isEmpty();
+        }
+
+        public boolean isRunningInAbnormalState() {
+            return !isRunningOnSingleServer() && !isStopped();
+        }
     }
 }

--- a/src/test/java/com/flightstats/hub/webhook/InternalWebhookClientTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/InternalWebhookClientTest.java
@@ -19,6 +19,7 @@ import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -42,6 +43,7 @@ class InternalWebhookClientTest {
     void setup() {
         when(localHostProperties.getUriScheme()).thenReturn("http://");
         internalWebhookClient = new InternalWebhookClient(hubCluster, restClient, localHostProperties);
+        reset(restClient);
     }
 
     @Test

--- a/src/test/java/com/flightstats/hub/webhook/InternalWebhookClientTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/InternalWebhookClientTest.java
@@ -30,6 +30,7 @@ class InternalWebhookClientTest {
     private static final String SERVER1 = "123.1.1";
     private static final String SERVER2 = "123.2.1";
     private static final String SERVER3 = "123.3.1";
+    private static final String SERVER4 = "123.4.1";
 
     @Mock
     private CuratorCluster hubCluster;
@@ -145,13 +146,96 @@ class InternalWebhookClientTest {
         mockWebhookRunEndpoint(SERVER2, false);
         mockWebhookRunEndpoint(SERVER1, true);
 
-        Optional<String> serverRun = internalWebhookClient.runOnOneServer(WEBHOOK_NAME, newArrayList(SERVER2, SERVER1, SERVER3));
+        Optional<String> serverRun = internalWebhookClient.runOnOneServer(WEBHOOK_NAME,
+                newArrayList(SERVER2, SERVER1, SERVER3));
 
         assertEquals(Optional.of(SERVER1), serverRun);
 
         verify(restClient).resource(runUrl(SERVER2));
         verify(restClient).resource(runUrl(SERVER1));
         verify(restClient, never()).resource(runUrl(SERVER3));
+    }
+
+    @Test
+    void testRunOnOnlyOneServer_ensuresRunningOnSingleServer() {
+        mockWebhookRunEndpoint(SERVER2, true);
+
+        Optional<String> serverRun = internalWebhookClient.runOnOnlyOneServer(WEBHOOK_NAME,
+                newArrayList(SERVER2));
+
+        assertEquals(Optional.of(SERVER2), serverRun);
+
+        verify(restClient).resource(runUrl(SERVER2));
+        verify(restClient, never()).resource(stopUrl(SERVER2));
+    }
+
+    @Test
+    void testRunOnOnlyOneServer_stopsOtherServers() {
+        mockWebhookRunEndpoint(SERVER2, true);
+        mockWebhookStopEndpoint(SERVER1, false);
+
+        Optional<String> serverRun = internalWebhookClient.runOnOnlyOneServer(WEBHOOK_NAME,
+                newArrayList(SERVER2, SERVER1));
+
+        assertEquals(Optional.of(SERVER2), serverRun);
+
+        verify(restClient).resource(runUrl(SERVER2));
+        verify(restClient, never()).resource(stopUrl(SERVER2));
+
+        verify(restClient).resource(stopUrl(SERVER1));
+        verify(restClient, never()).resource(runUrl(SERVER1));
+    }
+
+    @Test
+    void testRunOnOnlyOneServer_triesMultipleServersUntilOneSucceeds() {
+        mockWebhookRunEndpoint(SERVER2, false);
+        mockWebhookRunEndpoint(SERVER1, true);
+        mockWebhookStopEndpoint(SERVER2, false);
+        mockWebhookStopEndpoint(SERVER3, true);
+
+        Optional<String> serverRun = internalWebhookClient.runOnOnlyOneServer(WEBHOOK_NAME,
+                newArrayList(SERVER2, SERVER1, SERVER3));
+
+        assertEquals(Optional.of(SERVER1), serverRun);
+
+        verify(restClient).resource(runUrl(SERVER2));
+        verify(restClient).resource(runUrl(SERVER1));
+        verify(restClient, never()).resource(runUrl(SERVER3));
+
+        verify(restClient, never()).resource(stopUrl(SERVER1));
+        verify(restClient).resource(stopUrl(SERVER2));
+        verify(restClient).resource(stopUrl(SERVER3));
+    }
+
+    @Test
+    void testRunOnOnlyOneServer_whenRunningServersFailToRun_attemptsToRunOnServerWithFewestWebhooksThatHasNotBeenTried() {
+        when(hubCluster.getRandomServers()).thenReturn(newArrayList(SERVER1, SERVER4, SERVER2, SERVER3));
+        mockServerWebhookCountEndpoint(SERVER4, 6);
+        mockServerWebhookCountEndpoint(SERVER3, 1);
+        mockFailedServerWebhookCountEndpoint(SERVER2);
+        mockFailedServerWebhookCountEndpoint(SERVER1);
+
+        mockWebhookRunEndpoint(SERVER2, false);
+        mockWebhookRunEndpoint(SERVER1, false);
+        mockWebhookRunEndpoint(SERVER3, true);
+
+        mockWebhookStopEndpoint(SERVER2, false);
+        mockWebhookStopEndpoint(SERVER1, false);
+
+        Optional<String> serverRun = internalWebhookClient.runOnOnlyOneServer(WEBHOOK_NAME,
+                newArrayList(SERVER2, SERVER1));
+
+        assertEquals(Optional.of(SERVER3), serverRun);
+
+        verify(restClient).resource(runUrl(SERVER2));
+        verify(restClient).resource(runUrl(SERVER1));
+        verify(restClient).resource(runUrl(SERVER3));
+        verify(restClient, never()).resource(runUrl(SERVER4));
+
+        verify(restClient, never()).resource(stopUrl(SERVER3));
+        verify(restClient, never()).resource(stopUrl(SERVER4));
+        verify(restClient).resource(stopUrl(SERVER2));
+        verify(restClient).resource(stopUrl(SERVER1));
     }
 
     @Test
@@ -223,17 +307,17 @@ class InternalWebhookClientTest {
         ClientResponse clientResponse = mock(ClientResponse.class);
         WebResource webResource = mock(WebResource.class);
 
-        when(restClient.resource(runUrl(server))).thenReturn(webResource);
-        when(webResource.put(ClientResponse.class)).thenReturn(clientResponse);
         when(clientResponse.getStatus()).thenReturn(success ? 200 : 400);
+        when(webResource.put(ClientResponse.class)).thenReturn(clientResponse);
+        when(restClient.resource(runUrl(server))).thenReturn(webResource);
     }
 
     private void mockWebhookStopEndpoint(String server, boolean success) {
-        ClientResponse response = mock(ClientResponse.class);
-        when(response.getStatus()).thenReturn(success ? 200 : 500);
-
+        ClientResponse clientResponse = mock(ClientResponse.class);
         WebResource webResource = mock(WebResource.class);
-        when(webResource.put(ClientResponse.class)).thenReturn(response);
+
+        when(clientResponse.getStatus()).thenReturn(success ? 200 : 500);
+        when(webResource.put(ClientResponse.class)).thenReturn(clientResponse);
         when(restClient.resource(stopUrl(server))).thenReturn(webResource);
     }
 

--- a/src/test/java/com/flightstats/hub/webhook/RunningStateReaperTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/RunningStateReaperTest.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.when;
 @Execution(ExecutionMode.SAME_THREAD)
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class WebhookStateReaperTest {
+class RunningStateReaperTest {
     private static final DateTime start = new DateTime(2014, 12, 3, 20, 45, DateTimeZone.UTC);
     private static final ContentKey key = new ContentKey(start, "B");
     private static final String webhookName = "onTheHook";

--- a/src/test/java/com/flightstats/hub/webhook/WebhookCoordinatorActionDirectorTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/WebhookCoordinatorActionDirectorTest.java
@@ -1,0 +1,150 @@
+package com.flightstats.hub.webhook;
+
+import lombok.Builder;
+import lombok.Value;
+import lombok.experimental.Wither;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.Sets.newHashSet;
+import static junit.framework.Assert.assertEquals;
+
+public class WebhookCoordinatorActionDirectorTest {
+    @ParameterizedTest
+    @MethodSource("buildTestData")
+    void testShouldStart(TestData testData) {
+        WebhookCoordinator.WebhookActionDirector director = testData.getDirector();
+
+        assertEquals(testData.getTestName(), testData.isExpectedToStart(), director.webhookShouldStart());
+    }
+
+    @ParameterizedTest
+    @MethodSource("buildTestData")
+    void testShouldStop(TestData testData) {
+        WebhookCoordinator.WebhookActionDirector director = testData.getDirector();
+
+        assertEquals(testData.getTestName(), testData.isExpectedToStop(), director.webhookShouldStop());
+    }
+
+    @ParameterizedTest
+    @MethodSource("buildTestData")
+    void testShouldDoNothing(TestData testData) {
+        WebhookCoordinator.WebhookActionDirector director = testData.getDirector();
+
+        assertEquals(testData.getTestName(), testData.isExpectedToDoNothing(), director.webhookRequiresNoChanges());
+    }
+
+    @ParameterizedTest
+    @MethodSource("buildTestData")
+    void testShouldRestartOnJustOneServer(TestData testData) {
+        WebhookCoordinator.WebhookActionDirector director = testData.getDirector();
+
+        assertEquals(testData.getTestName(), testData.isExpectedToRestart(), director.webhookShouldRestartOnOneServerAndStopAnyOthers());
+    }
+
+    private static Stream<TestData> buildTestData() {
+        return Stream.of(
+                TestData.builder().testName("not started or paused should start")
+                        .webhookPaused(false)
+                        .runningServers(Collections.emptySet())
+                        .changed(false)
+                        .expectedToStart(true)
+                        .build(),
+                TestData.builder().testName("not started or paused but changed should start")
+                        .webhookPaused(false)
+                        .runningServers(Collections.emptySet())
+                        .changed(true)
+                        // this is a weird state that shouldn't happen, but both actions are acceptable
+                        .expectedToStart(true)
+                        .expectedToRestart(true)
+                        .build(),
+                TestData.builder().testName("not started and paused should do nothing")
+                        .webhookPaused(true)
+                        .runningServers(Collections.emptySet())
+                        .changed(false)
+                        .expectedToDoNothing(true)
+                        .build(),
+                TestData.builder().testName("not started and paused, but updated, should do nothing")
+                        .webhookPaused(true)
+                        .runningServers(Collections.emptySet())
+                        .changed(true)
+                        .expectedToDoNothing(true)
+                        .build(),
+                TestData.builder().testName("started and updated should restart")
+                        .webhookPaused(false)
+                        .runningServers(newHashSet("server1"))
+                        .changed(true)
+                        .expectedToRestart(true)
+                        .build(),
+                TestData.builder().testName("started on one server and not paused should do nothing")
+                        .webhookPaused(false)
+                        .runningServers(newHashSet("server1"))
+                        .changed(false)
+                        .expectedToDoNothing(true)
+                        .build(),
+                TestData.builder().testName("started on two servers and not paused should restart")
+                        .webhookPaused(false)
+                        .runningServers(newHashSet("server1", "server2"))
+                        .changed(false)
+                        .expectedToRestart(true)
+                        .build(),
+                TestData.builder().testName("started on two servers and not paused but updated should should restart")
+                        .webhookPaused(false)
+                        .runningServers(newHashSet("server1", "server2"))
+                        .changed(true)
+                        .expectedToRestart(true)
+                        .build(),
+                TestData.builder().testName("started on two servers and paused should stop")
+                        .webhookPaused(true)
+                        .runningServers(newHashSet("server1", "server2"))
+                        .changed(false)
+                        .expectedToStop(true)
+                        .build()
+        );
+    }
+
+    @Builder
+    @Wither
+    @Value
+    private static class TestData {
+        String testName;
+        boolean webhookPaused;
+        Set<String> runningServers;
+        boolean changed;
+
+        @Builder.Default
+        boolean expectedToStop = false;
+        @Builder.Default
+        boolean expectedToStart = false;
+        @Builder.Default
+        boolean expectedToDoNothing = false;
+        @Builder.Default
+        boolean expectedToRestart = false;
+
+        WebhookCoordinator.WebhookActionDirector getDirector() {
+            Webhook webhook = Webhook.builder().paused(isWebhookPaused()).build();
+
+            WebhookLeaderState.RunningState state = new WebhookLeaderState.RunningState(
+                    getLeadershipAcquired(),
+                    getRunningServers());
+            return new WebhookCoordinator.WebhookActionDirector(webhook, state, changed);
+        }
+
+        boolean getLeadershipAcquired() {
+            return !runningServers.isEmpty();
+        }
+
+    }
+
+    @Builder
+    @Wither
+    @Value
+    private static class Expectation {
+    }
+
+
+}

--- a/src/test/java/com/flightstats/hub/webhook/WebhookCoordinatorTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/WebhookCoordinatorTest.java
@@ -13,31 +13,22 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Sets.newHashSet;
-import static java.lang.String.format;
 import static junit.framework.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyCollectionOf;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.matches;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 @ExtendWith({MockitoExtension.class})
-@MockitoSettings(strictness = Strictness.LENIENT)
 @Execution(ExecutionMode.SAME_THREAD)
 class WebhookCoordinatorTest {
     @Mock
@@ -84,12 +75,11 @@ class WebhookCoordinatorTest {
                         .build());
 
         WebhookCoordinator webhookCoordinator = getWebhookCoordinator();
-        webhookCoordinator.ensureRunningOnOnlyOneServer(Webhook.builder().name(WEBHOOK_NAME).build(), false);
+        webhookCoordinator.ensureRunningOnOnlyOneServer(getUnpausedWebhook(), false);
 
         verify(webhookClient, never()).runOnServerWithFewestWebhooks(WEBHOOK_NAME);
-        verify(webhookClient, never()).runOnOneServer(eq(WEBHOOK_NAME), any());
-        verify(webhookClient, never()).stop(eq(WEBHOOK_NAME), anyString());
-        verify(webhookClient, never()).stop(eq(WEBHOOK_NAME), anyCollectionOf(String.class));
+        verify(webhookClient, never()).stop(eq(WEBHOOK_NAME), anyCollection());
+        verify(webhookClient, never()).runOnOnlyOneServer(eq(WEBHOOK_NAME), anyCollection());
     }
 
     @Test
@@ -100,14 +90,12 @@ class WebhookCoordinatorTest {
                         .runningServers(newHashSet())
                         .build());
 
-        when(webhookClient.runOnServerWithFewestWebhooks(WEBHOOK_NAME)).thenReturn(Optional.of(SERVER1));
-
         WebhookCoordinator webhookCoordinator = getWebhookCoordinator();
-        webhookCoordinator.ensureRunningOnOnlyOneServer(Webhook.builder().name(WEBHOOK_NAME).build(), false);
+        webhookCoordinator.ensureRunningOnOnlyOneServer(getUnpausedWebhook(), false);
 
-        verify(webhookClient).runOnServerWithFewestWebhooks(WEBHOOK_NAME);
-        verify(webhookClient, never()).runOnOneServer(eq(WEBHOOK_NAME), any());
-        verify(webhookClient, never()).stop(eq(WEBHOOK_NAME), anyString());
+        verify(webhookClient).runOnOnlyOneServer(WEBHOOK_NAME, newHashSet());
+        verify(webhookClient, never()).runOnServerWithFewestWebhooks(WEBHOOK_NAME);
+        verify(webhookClient, never()).stop(eq(WEBHOOK_NAME), anyCollection());
     }
 
     @Test
@@ -118,14 +106,12 @@ class WebhookCoordinatorTest {
                         .runningServers(newHashSet())
                         .build());
 
-        when(webhookClient.runOnServerWithFewestWebhooks(WEBHOOK_NAME)).thenReturn(Optional.of(SERVER1));
-
         WebhookCoordinator webhookCoordinator = getWebhookCoordinator();
-        webhookCoordinator.ensureRunningOnOnlyOneServer(Webhook.builder().name(WEBHOOK_NAME).build(), false);
+        webhookCoordinator.ensureRunningOnOnlyOneServer(getUnpausedWebhook(), false);
 
         verify(webhookClient).runOnServerWithFewestWebhooks(WEBHOOK_NAME);
-        verify(webhookClient, never()).runOnOneServer(eq(WEBHOOK_NAME), anyCollectionOf(String.class));
-        verify(webhookClient, never()).stop(eq(WEBHOOK_NAME), anyString());
+        verify(webhookClient, never()).runOnOnlyOneServer(eq(WEBHOOK_NAME), anyCollection());
+        verify(webhookClient, never()).stop(eq(WEBHOOK_NAME), anyCollection());
     }
 
     @Test
@@ -136,17 +122,12 @@ class WebhookCoordinatorTest {
                         .runningServers(newHashSet(SERVER1, SERVER2, SERVER3))
                         .build());
 
-        when(webhookClient.stop(WEBHOOK_NAME, SERVER1)).thenReturn(true);
-        when(webhookClient.stop(WEBHOOK_NAME, SERVER2)).thenReturn(true);
-        when(webhookClient.stop(WEBHOOK_NAME, SERVER3)).thenReturn(true);
-
         WebhookCoordinator webhookCoordinator = getWebhookCoordinator();
-        webhookCoordinator.ensureRunningOnOnlyOneServer(Webhook.builder().name(WEBHOOK_NAME).build(), false);
+        webhookCoordinator.ensureRunningOnOnlyOneServer(getUnpausedWebhook(), false);
 
-        verify(webhookClient, times(2)).stop(eq(WEBHOOK_NAME), matches(
-                format("(%s|%s|%s)", SERVER1, SERVER2, SERVER3)));
-        verify(webhookClient, never()).runOnOneServer(eq(WEBHOOK_NAME), anyCollectionOf(String.class));
+        verify(webhookClient).runOnOnlyOneServer(WEBHOOK_NAME, newHashSet(SERVER1, SERVER2, SERVER3));
         verify(webhookClient, never()).runOnServerWithFewestWebhooks(WEBHOOK_NAME);
+        verify(webhookClient, never()).stop(eq(WEBHOOK_NAME), anyCollection());
     }
 
     @Test
@@ -156,36 +137,30 @@ class WebhookCoordinatorTest {
                         .leadershipAcquired(true)
                         .runningServers(newHashSet(SERVER1))
                         .build());
-        when(webhookClient.runOnOneServer(WEBHOOK_NAME, newArrayList(SERVER1))).thenReturn(Optional.of(SERVER1));
 
         WebhookCoordinator webhookCoordinator = getWebhookCoordinator();
-        webhookCoordinator.ensureRunningOnOnlyOneServer(Webhook.builder().name(WEBHOOK_NAME).build(), true);
+        webhookCoordinator.ensureRunningOnOnlyOneServer(getUnpausedWebhook(), true);
 
-        verify(webhookClient).runOnOneServer(WEBHOOK_NAME, newArrayList(SERVER1));
-        verify(webhookClient, never()).stop(eq(WEBHOOK_NAME), anyString());
+        verify(webhookClient).runOnOnlyOneServer(WEBHOOK_NAME, newHashSet(SERVER1));
+        verify(webhookClient, never()).runOnServerWithFewestWebhooks(WEBHOOK_NAME);
+        verify(webhookClient, never()).stop(eq(WEBHOOK_NAME), anyCollection());
     }
 
     @Test
-    void testWhenWebhookHasChanged_isRunOnAServerThatItWasAlreadyRunningOnAndOnlyOneServer() {
-        // TODO: this is a weird case, because it doesn't check that it's trying to run on a server that hasn't been removed;
-        // it just picks one that it was running on before it was deleted
+    void testWhenWebhookHasChanged_isRunOnOnlyOneServer() {
         when(webhookLeaderState.getState(WEBHOOK_NAME)).thenReturn(
                 WebhookLeaderState.RunningState.builder()
                         .leadershipAcquired(true)
                         .runningServers(newHashSet(SERVER1, SERVER2, SERVER3))
                         .build());
 
-        when(webhookClient.runOnOneServer(WEBHOOK_NAME, newArrayList(SERVER1, SERVER2, SERVER3))).thenReturn(Optional.of(SERVER1));
-        when(webhookClient.stop(WEBHOOK_NAME, SERVER1)).thenReturn(true);
-        when(webhookClient.stop(WEBHOOK_NAME, SERVER2)).thenReturn(true);
-        when(webhookClient.stop(WEBHOOK_NAME, SERVER3)).thenReturn(true);
 
         WebhookCoordinator webhookCoordinator = getWebhookCoordinator();
-        webhookCoordinator.ensureRunningOnOnlyOneServer(Webhook.builder().name(WEBHOOK_NAME).build(), true);
+        webhookCoordinator.ensureRunningOnOnlyOneServer(getUnpausedWebhook(), true);
 
-        verify(webhookClient, times(2)).stop(eq(WEBHOOK_NAME), matches(
-                format("(%s|%s|%s)", SERVER1, SERVER2, SERVER3)));
-        verify(webhookClient).runOnOneServer(eq(WEBHOOK_NAME), anyCollectionOf(String.class));
+        verify(webhookClient).runOnOnlyOneServer(WEBHOOK_NAME, newHashSet(SERVER3, SERVER2, SERVER1));
+        verify(webhookClient, never()).stop(eq(WEBHOOK_NAME), anyCollection());
+        verify(webhookClient, never()).runOnServerWithFewestWebhooks(WEBHOOK_NAME);
     }
 
     @Test
@@ -199,9 +174,9 @@ class WebhookCoordinatorTest {
         webhookCoordinator.ensureRunningOnOnlyOneServer(tagWebhook, false);
 
         verify(webhookLeaderState, never()).getState(WEBHOOK_NAME);
-        verify(webhookClient, never()).runOnOneServer(eq(WEBHOOK_NAME), anyCollectionOf(String.class));
-        verify(webhookClient, never()).stop(eq(WEBHOOK_NAME), anyCollectionOf(String.class));
-        verify(webhookClient, never()).stop(eq(WEBHOOK_NAME), anyString());
+        verify(webhookClient, never()).stop(eq(WEBHOOK_NAME), anyCollection());
+        verify(webhookClient, never()).runOnServerWithFewestWebhooks(WEBHOOK_NAME);
+        verify(webhookClient, never()).runOnOnlyOneServer(eq(WEBHOOK_NAME), any());
     }
 
     @Test
@@ -218,6 +193,13 @@ class WebhookCoordinatorTest {
         getWebhookCoordinator();
         Map<HubServices.TYPE, List<Service>> services = HubServices.getServices();
         services.forEach((type, svcs) -> assertTrue(type + " has services registered", svcs.isEmpty()));
+    }
+
+    private Webhook getUnpausedWebhook() {
+        return Webhook.builder()
+                .name(WEBHOOK_NAME)
+                .paused(false)
+                .build();
     }
 
     private WebhookCoordinator getWebhookCoordinator() {

--- a/src/test/java/com/flightstats/hub/webhook/WebhookLeaderStateIntTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/WebhookLeaderStateIntTest.java
@@ -18,9 +18,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
 
 import static com.google.common.collect.Sets.newHashSet;
 import static java.lang.String.format;
+import static java.util.stream.Collectors.toSet;
 import static org.apache.zookeeper.KeeperException.NodeExistsException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -101,11 +104,20 @@ class WebhookLeaderStateIntTest {
         assertEquals(3, webhooks.size());
         assertEquals(newHashSet(WEBHOOK_WITH_LOCK, WEBHOOK_WITH_A_FEW_LEASES, WEBHOOK_WITH_LEASE), newHashSet(webhooks));
 
-        assertTrue(webhookLeaderState.isActiveWebhook(WEBHOOK_WITH_A_FEW_LEASES));
-        assertTrue(webhookLeaderState.isActiveWebhook(WEBHOOK_WITH_LEASE));
-        assertTrue(webhookLeaderState.isActiveWebhook(WEBHOOK_WITH_LOCK));
+        WebhookLeaderState.RunningState state = WebhookLeaderState.RunningState.builder().build();
+        assertEquals(
+                state.withLeadershipAcquired(true).withRunningServers(getServersWithPort(SERVER_IP1, SERVER_IP2)),
+                webhookLeaderState.getState(WEBHOOK_WITH_A_FEW_LEASES));
+        assertEquals(
+                state.withLeadershipAcquired(true).withRunningServers(getServersWithPort(SERVER_IP1)),
+                webhookLeaderState.getState(WEBHOOK_WITH_LEASE));
+        assertEquals(
+                state.withLeadershipAcquired(true).withRunningServers(newHashSet()),
+                webhookLeaderState.getState(WEBHOOK_WITH_LOCK));
 
-        assertFalse(webhookLeaderState.isActiveWebhook(EMPTY_WEBHOOK));
+        assertEquals(
+                state.withLeadershipAcquired(false).withRunningServers(newHashSet()),
+                webhookLeaderState.getState(EMPTY_WEBHOOK));
     }
 
     private void createWebhook(String webhook) {
@@ -132,5 +144,11 @@ class WebhookLeaderStateIntTest {
         } catch (Exception e) {
             fail(e.getMessage());
         }
+    }
+
+    private Set<String> getServersWithPort(String... servers) {
+        return Stream.of(servers)
+                .map(server -> format("%s:0", server))
+                .collect(toSet());
     }
 }

--- a/src/test/java/com/flightstats/hub/webhook/WebhookLeaderStateIntTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/WebhookLeaderStateIntTest.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.when;
 @Slf4j
 @Execution(ExecutionMode.SAME_THREAD)
 @ExtendWith(MockitoExtension.class)
-class ActiveWebhooksIntTest {
+class WebhookLeaderStateIntTest {
     private static final String WEBHOOK_LEADER_PATH = "/WebhookLeader";
     private static final String WEBHOOK_WITH_LEASE = "webhook1";
     private static final String WEBHOOK_WITH_A_FEW_LEASES = "webhook4";
@@ -95,17 +95,17 @@ class ActiveWebhooksIntTest {
 
         WebhookLeaderLocks webhookLeaderLocks = new WebhookLeaderLocks(zooKeeperUtils);
         ActiveWebhookSweeper activeWebhookSweeper = new ActiveWebhookSweeper(webhookLeaderLocks, mock(StatsdReporter.class));
-        ActiveWebhooks activeWebhooks = new ActiveWebhooks(webhookLeaderLocks, activeWebhookSweeper, webhookProperties, localHostProperties);
+        WebhookLeaderState webhookLeaderState = new WebhookLeaderState(webhookLeaderLocks, activeWebhookSweeper, webhookProperties, localHostProperties);
 
         List<String> webhooks = curator.getChildren().forPath(WEBHOOK_LEADER_PATH);
         assertEquals(3, webhooks.size());
         assertEquals(newHashSet(WEBHOOK_WITH_LOCK, WEBHOOK_WITH_A_FEW_LEASES, WEBHOOK_WITH_LEASE), newHashSet(webhooks));
 
-        assertTrue(activeWebhooks.isActiveWebhook(WEBHOOK_WITH_A_FEW_LEASES));
-        assertTrue(activeWebhooks.isActiveWebhook(WEBHOOK_WITH_LEASE));
-        assertTrue(activeWebhooks.isActiveWebhook(WEBHOOK_WITH_LOCK));
+        assertTrue(webhookLeaderState.isActiveWebhook(WEBHOOK_WITH_A_FEW_LEASES));
+        assertTrue(webhookLeaderState.isActiveWebhook(WEBHOOK_WITH_LEASE));
+        assertTrue(webhookLeaderState.isActiveWebhook(WEBHOOK_WITH_LOCK));
 
-        assertFalse(activeWebhooks.isActiveWebhook(EMPTY_WEBHOOK));
+        assertFalse(webhookLeaderState.isActiveWebhook(EMPTY_WEBHOOK));
     }
 
     private void createWebhook(String webhook) {

--- a/src/test/java/com/flightstats/hub/webhook/WebhookLeaderStateRunningStateTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/WebhookLeaderStateRunningStateTest.java
@@ -1,0 +1,103 @@
+package com.flightstats.hub.webhook;
+
+import lombok.Builder;
+import lombok.Value;
+import lombok.experimental.Wither;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static com.google.common.collect.Sets.newHashSet;
+import static junit.framework.Assert.assertEquals;
+
+class WebhookLeaderStateRunningStateTest {
+    @ParameterizedTest
+    @MethodSource("buildTestData")
+    void testRunning(TestData testData) {
+        assertEquals(testData.getTestName(), testData.isRunning(), testData.getState().isRunningOnSingleServer());
+    }
+
+    @ParameterizedTest
+    @MethodSource("buildTestData")
+    void testStopped(TestData testData) {
+        assertEquals(testData.getTestName(), testData.isStopped(), testData.getState().isStopped());
+    }
+
+    @ParameterizedTest
+    @MethodSource("buildTestData")
+    void testAbnormalState(TestData testData) {
+        assertEquals(testData.getTestName(), testData.isInAbnormalState(), testData.getState().isRunningInAbnormalState());
+    }
+
+    private static Stream<TestData> buildTestData() {
+        WebhookLeaderState.RunningState state = WebhookLeaderState.RunningState.builder().build();
+        return Stream.of(
+                TestData.builder().testName("stopped")
+                        .state(state
+                                .withLeadershipAcquired(false)
+                                .withRunningServers(newHashSet()))
+                        .running(false)
+                        .stopped(true)
+                        .inAbnormalState(false)
+                        .build(),
+
+                TestData.builder().testName("running on one server")
+                        .state(state
+                                .withLeadershipAcquired(true)
+                                .withRunningServers(newHashSet("a")))
+                        .running(true)
+                        .stopped(false)
+                        .inAbnormalState(false)
+                        .build(),
+
+                TestData.builder().testName("running on more than one server")
+                        .state(state
+                                .withLeadershipAcquired(true)
+                                .withRunningServers(newHashSet("a", "b")))
+                        .running(false)
+                        .stopped(false)
+                        .inAbnormalState(true)
+                        .build(),
+
+                TestData.builder().testName("reports as running on one server, but the server hasn't set a lock")
+                        .state(state
+                                .withLeadershipAcquired(false)
+                                .withRunningServers(newHashSet("a")))
+                        .running(false)
+                        .stopped(false)
+                        .inAbnormalState(true)
+                        .build(),
+
+                TestData.builder().testName("reports as running on multiple servers, but the server hasn't set a lock")
+                        .state(state
+                                .withLeadershipAcquired(false)
+                                .withRunningServers(newHashSet("a", "b")))
+                        .running(false)
+                        .stopped(false)
+                        .inAbnormalState(true)
+                        .build(),
+
+                TestData.builder().testName("has a lock that says it's running, but we don't know where")
+                        .state(state
+                                .withLeadershipAcquired(true)
+                                .withRunningServers(newHashSet()))
+                        .running(false)
+                        .stopped(false)
+                        .inAbnormalState(true)
+                        .build()
+        );
+    }
+
+    @Builder
+    @Wither
+    @Value
+    private static class TestData {
+        String testName;
+        WebhookLeaderState.RunningState state;
+
+        boolean running;
+        boolean stopped;
+        boolean inAbnormalState;
+    }
+}

--- a/src/test/java/com/flightstats/hub/webhook/WebhookLeaderStateTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/WebhookLeaderStateTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class ActiveWebhooksTest {
+class WebhookLeaderStateTest {
     private static final int HUB_PORT = 8080;
 
     private static final String WEBHOOK_WITH_LEASE = "webhook1";
@@ -39,11 +39,11 @@ class ActiveWebhooksTest {
     private LocalHostProperties localHostProperties;
     @Mock
     private WebhookProperties webhookProperties;
-    private ActiveWebhooks activeWebhooks;
+    private WebhookLeaderState webhookLeaderState;
 
     @BeforeEach
     public void setup() {
-        activeWebhooks = new ActiveWebhooks(webhookLeaderLocks, activeWebhookSweeper, webhookProperties, localHostProperties);
+        webhookLeaderState = new WebhookLeaderState(webhookLeaderLocks, activeWebhookSweeper, webhookProperties, localHostProperties);
     }
 
     @Test
@@ -51,7 +51,7 @@ class ActiveWebhooksTest {
         when(webhookLeaderLocks.getServerLeases(WEBHOOK_WITH_A_FEW_LEASES))
                 .thenReturn(newHashSet(SERVER_IP2, SERVER_IP1));
         when(localHostProperties.getPort()).thenReturn(HUB_PORT);
-        Set<String> servers = activeWebhooks.getServers(WEBHOOK_WITH_A_FEW_LEASES);
+        Set<String> servers = webhookLeaderState.getServers(WEBHOOK_WITH_A_FEW_LEASES);
 
         assertEquals(getServersWithPort(SERVER_IP1, SERVER_IP2), servers);
     }
@@ -61,7 +61,7 @@ class ActiveWebhooksTest {
     void testGetServers_returnsAnEmptyListIfThereAreNoLeases() {
         when(webhookLeaderLocks.getServerLeases(EMPTY_WEBHOOK))
                 .thenReturn(newHashSet());
-        Set<String> servers = activeWebhooks.getServers(EMPTY_WEBHOOK);
+        Set<String> servers = webhookLeaderState.getServers(EMPTY_WEBHOOK);
 
         assertEquals(newHashSet(), servers);
     }
@@ -71,7 +71,7 @@ class ActiveWebhooksTest {
         when(webhookLeaderLocks.getWebhooks())
                 .thenReturn(newHashSet(WEBHOOK_WITH_A_FEW_LEASES, WEBHOOK_WITH_LEASE, WEBHOOK_WITH_LOCK));
 
-        assertTrue(activeWebhooks.isActiveWebhook(WEBHOOK_WITH_LEASE));
+        assertTrue(webhookLeaderState.isActiveWebhook(WEBHOOK_WITH_LEASE));
     }
 
 
@@ -80,7 +80,7 @@ class ActiveWebhooksTest {
         when(webhookLeaderLocks.getWebhooks())
                 .thenReturn(newHashSet(WEBHOOK_WITH_A_FEW_LEASES, WEBHOOK_WITH_LEASE, WEBHOOK_WITH_LOCK));
 
-        assertFalse(activeWebhooks.isActiveWebhook(EMPTY_WEBHOOK));
+        assertFalse(webhookLeaderState.isActiveWebhook(EMPTY_WEBHOOK));
     }
 
     private Set<String> getServersWithPort(String... servers) {

--- a/src/test/java/com/flightstats/hub/webhook/WebhookLeaderStateTest.java
+++ b/src/test/java/com/flightstats/hub/webhook/WebhookLeaderStateTest.java
@@ -17,6 +17,7 @@ import static java.util.stream.Collectors.toSet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -44,6 +45,7 @@ class WebhookLeaderStateTest {
     @BeforeEach
     void setup() {
         webhookLeaderState = new WebhookLeaderState(webhookLeaderLocks, activeWebhookSweeper, webhookProperties, localHostProperties);
+        reset(webhookLeaderLocks);
     }
 
     @Test


### PR DESCRIPTION
The bug fix (in the last commit) addresses the following scenario:
1. A user pauses a webhook
2. The WebhookCoordinator scheduled task runs, sees that the paused webhook is not currently running, and sends off an internal request to start it up. 
3. Somewhere down the stack in that internal start resource call, the run request fails (because the webhook is paused) and returns a 400 error.
4. This happens on each node every x (x=5?) minutes. When I paused all the batch webhooks, this caused havoc on the cluster.

It fixes it by, y'know, taking webhook paused state into consideration when the `WebhookCoordinator` decides what actions to take re: running the webhook.

Commits 2, 4, 6, and 7 contain actual refactoring and changes to behavior. Those commit messages include the main class to look at and the responsibility of that class.