### PR TITLE
HUB-908: Add gc log rotation

### DIFF
--- a/docker/run
+++ b/docker/run
@@ -33,13 +33,9 @@ JAVA_OPTS="
  -Xmx$MAX_HEAP
  -Xms$MIN_HEAP
  -XX:NewSize=$NEW_SIZE
- -XX:+UseG1GC
- -XX:MaxGCPauseMillis=100
  -XX:+HeapDumpOnOutOfMemoryError
  -XX:HeapDumpPath=/mnt/log
  -XX:+ExitOnOutOfMemoryError
- -Dsun.rmi.dgc.client.gcInterval=300000
- -Dsun.rmi.dgc.server.gcInterval=300000
  -agentlib:jdwp=transport=dt_socket,address=$DEBUG_PORT,server=y,suspend=n
  -Djboss.platform.mbeanserver
  -Dcom.sun.management.jmxremote=true
@@ -49,12 +45,19 @@ JAVA_OPTS="
  -Dcom.sun.management.jmxremote.rmi.port=$JMXREMOTE_PORT
  -Dcom.sun.management.jmxremote.ssl=false
  -Dcom.sun.management.jmxremote.authenticate=false
- -XX:+PrintGCDetails
  -XX:+PrintTenuringDistribution
- -XX:+PrintGCDateStamps
  -Djava.awt.headless=true
  -Dsun.net.inetaddr.ttl=0
- -Xloggc:${LOG_DIR}/gc.log-$(date -u '+%Y-%m-%d-%H-%M-%S')
+ -XX:+UseG1GC
+ -XX:MaxGCPauseMillis=100
+ -Dsun.rmi.dgc.client.gcInterval=300000
+ -Dsun.rmi.dgc.server.gcInterval=300000
+ -XX:+PrintGCDetails
+ -XX:+PrintGCDateStamps
+ -XX:+UseGCLogFileRotation
+ -XX:NumberOfGCLogFiles=10
+ -XX:GCLogFileSize=100M
+ -Xloggc:${LOG_DIR}/gc.log
  -Dfile.encoding=UTF-8
  -Dlogback.configurationFile=${CONFIG_DIR}/logback.xml"
 


### PR DESCRIPTION
This should give us a max of 10 100MB files of gc logs. It looks like iad.prod goes through about 1.5GB of gc logs in a week, so this keeps 'em around for a very little while, but maybe not long enough? I deployed this to iad.dev, where it takes about a week to get 150-200MB of logs, so I should be able to confirm the settings work as expected on Monday.

Naming pattern will be `gc.log.0`, `gc.log.1.current`, `gc.log.2`, etc, (possibly with a non-current `gc.log.1`?) where it'll just kinda round-robin and overwrite old data, as far as I can tell.

I'm not a java 8/JVM expert, so maybe there's a better way to go.