### PR TITLE
Track local webhooks better and provide more local statistics

### DIFF
--- a/src/main/java/com/flightstats/hub/cluster/Lockable.java
+++ b/src/main/java/com/flightstats/hub/cluster/Lockable.java
@@ -2,6 +2,6 @@ package com.flightstats.hub.cluster;
 
 public interface Lockable {
 
-    void takeLeadership(Leadership leadership) throws Exception;
+    void takeLeadership(Leadership leadership);
 
 }

--- a/src/main/java/com/flightstats/hub/webhook/InternalWebhookResource.java
+++ b/src/main/java/com/flightstats/hub/webhook/InternalWebhookResource.java
@@ -22,7 +22,10 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
-import java.util.*;
+import java.util.Collection;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 
 import static com.flightstats.hub.constant.InternalResourceDescription.WEBHOOK_DESCRIPTION;

--- a/src/main/java/com/flightstats/hub/webhook/InternalWebhookResource.java
+++ b/src/main/java/com/flightstats/hub/webhook/InternalWebhookResource.java
@@ -22,10 +22,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
-import java.util.Collection;
-import java.util.Map;
-import java.util.TreeMap;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import static com.flightstats.hub.constant.InternalResourceDescription.WEBHOOK_DESCRIPTION;
@@ -188,8 +185,13 @@ public class InternalWebhookResource {
     @Produces(MediaType.APPLICATION_JSON)
     public Response running() {
         ObjectNode root = objectMapper.createObjectNode();
-        ArrayNode arrayNode = root.putArray(localHostProperties.getName());
-        localWebhookRunner.getRunning().forEach(arrayNode::add);
+        ObjectNode hostNode = root.putObject(localHostProperties.getName());
+
+        localWebhookRunner.getRunning().entrySet().stream().sorted(Map.Entry.comparingByKey())
+                .forEach(e -> {
+                     ObjectNode webhookNode = hostNode.putObject(e.getKey());
+                     e.getValue().forEach(webhookNode::putPOJO);
+                });
 
         return Response.ok(root).build();
     }

--- a/src/main/java/com/flightstats/hub/webhook/LocalWebhookRunner.java
+++ b/src/main/java/com/flightstats/hub/webhook/LocalWebhookRunner.java
@@ -152,12 +152,13 @@ public class LocalWebhookRunner {
                 WebhookLeader existingLeader = localLeaders.put(webhookName, webhookLeader);
                 if (null != existingLeader) {
                     log.error("Starting a second webhook leader for {}", existingLeader);
-                    statsdReporter.incrementCounter("webhook.multileader", "name:" + webhookName);
+                    statsdReporter.incrementCounter("webhook.leader.over", "name:" + webhookName);
                 }
             }
             else {
                 if(!localLeaders.remove(webhookName, webhookLeader)) {
                     log.error("Attempted to remove an unexpected webhook leader for {}", webhookName);
+                    statsdReporter.incrementCounter("webhook.leader.under", "name:" + webhookName);
                 }
             }
         }

--- a/src/main/java/com/flightstats/hub/webhook/LocalWebhookRunner.java
+++ b/src/main/java/com/flightstats/hub/webhook/LocalWebhookRunner.java
@@ -4,7 +4,6 @@ import com.flightstats.hub.config.properties.WebhookProperties;
 import com.flightstats.hub.dao.Dao;
 import com.flightstats.hub.util.RuntimeInterruptedException;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import javax.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
@@ -12,7 +11,9 @@ import de.jkeylockmanager.manager.KeyLockManager;
 import de.jkeylockmanager.manager.KeyLockManagers;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.*;
+import javax.inject.Inject;
+import java.util.Collection;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;

--- a/src/main/java/com/flightstats/hub/webhook/LocalWebhookRunner.java
+++ b/src/main/java/com/flightstats/hub/webhook/LocalWebhookRunner.java
@@ -80,7 +80,7 @@ public class LocalWebhookRunner {
                 return true;
             }
             log.info("webhook has changed {} to {}; stopping", runningWebhook, daoWebhook);
-            stop(name);
+            stopWithLock(name);
         }
         log.info("starting {}", name);
         return start(daoWebhook);

--- a/src/main/java/com/flightstats/hub/webhook/WebhookLeader.java
+++ b/src/main/java/com/flightstats/hub/webhook/WebhookLeader.java
@@ -351,6 +351,7 @@ class WebhookLeader {
                 .put("startTimeMillis", leadershipStartTime)
                 .put("lastUpdated", lastUpdated.get())
                 .put("hasLeadership", hasLeadership())
+                .put("executorState", Optional.ofNullable(executorService).map(e -> e.isShutdown() ? "SHUTDOWN" : "ACTIVE").orElse("NULL"))
                 .build();
     }
 

--- a/src/test/java/com/flightstats/hub/cluster/DistributedAsyncLockRunnerTest.java
+++ b/src/test/java/com/flightstats/hub/cluster/DistributedAsyncLockRunnerTest.java
@@ -1,6 +1,7 @@
 package com.flightstats.hub.cluster;
 
 import com.flightstats.hub.test.IntegrationTestSetup;
+import lombok.SneakyThrows;
 import org.apache.curator.framework.CuratorFramework;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -102,8 +103,9 @@ class DistributedAsyncLockRunnerTest {
             this.sleepMillis = sleepMillis;
         }
 
+        @SneakyThrows
         @Override
-        public void takeLeadership(Leadership leadership) throws Exception {
+        public void takeLeadership(Leadership leadership) {
             Thread.sleep(sleepMillis);
             List<String> newLockList = lockList.get();
             newLockList.add(name);


### PR DESCRIPTION
* Add statistics to the internal endpoint around the start time of webhook leadership, if it thinks it has leadership, and the latest uri
* Manage the current local leaders map via events/listeners; previously the death of a webhook wouldn't remove it from the map