### PR TITLE
Permission Issues with latest Docker Image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,6 +20,8 @@ RUN useradd -u $USER_ID -g $USER_ID -s /bin/bash $USER_NAME
 ADD hub /opt/hub
 ADD run /opt/hub/bin/run
 RUN chown -Rv $USER_NAME:$USER_NAME /opt/hub
+RUN chown -Rv $USER_NAME:$USER_NAME /etc/hub
+RUN chown -Rv $USER_NAME:$USER_NAME /mnt/spoke
 RUN chmod 770 -Rv /opt/hub/bin
 USER $USER_NAME
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,8 @@ RUN useradd -u $USER_ID -g $USER_ID -s /bin/bash $USER_NAME
 ADD hub /opt/hub
 ADD run /opt/hub/bin/run
 RUN chown -Rv $USER_NAME:$USER_NAME /opt/hub
-RUN chown -Rv $USER_NAME:$USER_NAME /etc/hub
+RUN chown -Rv $USER_NAME:$USER_NAME /etc/hub/hub.properties
+RUN chown -Rv $USER_NAME:$USER_NAME /etc/hub/logback.xml
 RUN chown -Rv $USER_NAME:$USER_NAME /mnt/spoke
 RUN chmod 770 -Rv /opt/hub/bin
 USER $USER_NAME


### PR DESCRIPTION
When trying to start up the latest Docker image, I encountered some permission issues in the logs. 

```java
16:25:40,068 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Found resource [/etc/hub/logback.xml] at [file:/etc/hub/logback.xml]
16:25:40,076 |-ERROR in ch.qos.logback.classic.joran.JoranConfigurator@f6c48ac - Could not open URL [file:/etc/hub/logback.xml]. java.io.FileNotFoundException: /etc/hub/logback.xml (Permission denied)
	at java.io.FileNotFoundException: /etc/hub/logback.xml (Permission denied)
	at 	at java.io.FileInputStream.open0(Native Method)
	at 	at java.io.FileInputStream.open(FileInputStream.java:195)
	at 	at java.io.FileInputStream.<init>(FileInputStream.java:138)
	at 	at java.io.FileInputStream.<init>(FileInputStream.java:93)
	at 	at sun.net.www.protocol.file.FileURLConnection.connect(FileURLConnection.java:90)
	at 	at sun.net.www.protocol.file.FileURLConnection.getInputStream(FileURLConnection.java:188)
	at 	at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:52)
	at 	at ch.qos.logback.classic.util.ContextInitializer.configureByResource(ContextInitializer.java:75)
	at 	at ch.qos.logback.classic.util.ContextInitializer.autoConfig(ContextInitializer.java:150)
	at 	at org.slf4j.impl.StaticLoggerBinder.init(StaticLoggerBinder.java:84)
	at 	at org.slf4j.impl.StaticLoggerBinder.<clinit>(StaticLoggerBinder.java:55)
	at 	at org.slf4j.LoggerFactory.bind(LoggerFactory.java:150)
	at 	at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:124)
	at 	at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:412)
	at 	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:357)
	at 	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:383)
	at 	at com.flightstats.hub.app.HubMain.<clinit>(HubMain.java:14)

Exception in thread "main" java.lang.RuntimeException: /etc/hub/hub.properties (Permission denied)
	at com.flightstats.hub.config.properties.PropertiesLoader.load(PropertiesLoader.java:71)
	at com.flightstats.hub.app.HubMain.main(HubMain.java:24)
```

It appears that the user that the user the image utilizes does not have all the permissions that it needs. This PR gives the user that the container chooses to use permissions to own these directories.