### PR TITLE
Add in JMX monitoring of Jetty; add ability to adjust thread pool size

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,7 @@ dependencies {
     compile 'org.eclipse.jetty:jetty-servlet:9.4.8.v20171121'
     compile 'org.eclipse.jetty:jetty-servlets:9.4.8.v20171121'
     compile 'org.eclipse.jetty.websocket:javax-websocket-server-impl:9.4.8.v20171121'
+    compile 'org.eclipse.jetty:jetty-jmx:9.4.8.v20171121'
 
     compile 'org.glassfish.jersey.containers:jersey-container-jetty-http:2.26'
     compile 'org.glassfish.jersey.core:jersey-common:2.26'

--- a/src/main/java/com/flightstats/hub/cluster/DistributedAsyncLockRunner.java
+++ b/src/main/java/com/flightstats/hub/cluster/DistributedAsyncLockRunner.java
@@ -1,5 +1,6 @@
 package com.flightstats.hub.cluster;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.inject.Inject;
@@ -26,7 +27,7 @@ public class DistributedAsyncLockRunner {
     public DistributedAsyncLockRunner(String lockPath, DistributedLeaderLockManager leadershipLockManager) {
         this.lockPath = lockPath;
         this.leadershipLockManager = leadershipLockManager;
-        this.executorService = Executors.newSingleThreadExecutor();
+        this.executorService = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat("AsyncLockRunner-" + lockPath).build());
     }
 
     public void setLockPath(String lockPath) {

--- a/src/main/java/com/flightstats/hub/config/properties/AppProperties.java
+++ b/src/main/java/com/flightstats/hub/config/properties/AppProperties.java
@@ -95,4 +95,8 @@ public class AppProperties {
         return propertiesLoader.getProperty("app.keyStorePath", "/etc/ssl/");
     }
 
+    public int getMaxJettyThreadPoolSize() {
+        // this magic number comes from the default constructor of QueuedThreadPool
+        return propertiesLoader.getProperty("jetty.maxThreadPoolSize", 200);
+    }
 }

--- a/src/main/java/com/flightstats/hub/util/ChunkOutputStream.java
+++ b/src/main/java/com/flightstats/hub/util/ChunkOutputStream.java
@@ -4,6 +4,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -12,10 +13,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.function.Function;
 
 @Slf4j
 public class ChunkOutputStream extends OutputStream {
+    private final static ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("ChunkOutputStream-%d").build()
 
     private static final int MEGABYTES = 1024 * 1024;
 
@@ -33,7 +36,7 @@ public class ChunkOutputStream extends OutputStream {
         this.chunkFunction = chunkFunction;
 
         this.chunk = new Chunk(count, getSize(count));
-        service = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(threads));
+        service = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(threads, threadFactory));
         log.info("creating ChunkOutputStream with {} threads", threads);
     }
 

--- a/src/main/java/com/flightstats/hub/util/ChunkOutputStream.java
+++ b/src/main/java/com/flightstats/hub/util/ChunkOutputStream.java
@@ -18,7 +18,7 @@ import java.util.function.Function;
 
 @Slf4j
 public class ChunkOutputStream extends OutputStream {
-    private final static ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("ChunkOutputStream-%d").build()
+    private final static ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("ChunkOutputStream-%d").build();
 
     private static final int MEGABYTES = 1024 * 1024;
 

--- a/src/main/java/com/flightstats/hub/webhook/WebhookLeader.java
+++ b/src/main/java/com/flightstats/hub/webhook/WebhookLeader.java
@@ -18,6 +18,7 @@ import com.flightstats.hub.util.RuntimeInterruptedException;
 import com.flightstats.hub.util.Sleeper;
 import com.flightstats.hub.util.TimeUtil;
 import com.flightstats.hub.webhook.strategy.WebhookStrategy;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import lombok.extern.slf4j.Slf4j;
 import org.joda.time.DateTime;
 
@@ -123,7 +124,7 @@ class WebhookLeader {
         }
         log.info("taking leadership {} {}", webhook.getName(), leadership.hasLeadership());
         statsdReporter.incrementEventStart(LEADERSHIP_METRIC, "name:" + webhook.getName());
-        executorService = Executors.newCachedThreadPool();
+        executorService = Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("WebhookLeader-" + webhook.getName() + "-%d").build());
         semaphore = new Semaphore(webhook.getParallelCalls());
         retryer = WebhookRetryer.builder()
                 .readTimeoutSeconds(webhook.getCallbackTimeoutSeconds())


### PR DESCRIPTION
This should allow us to introspect into Jetty's behavior to see if it's behind the request latency. It also allows for tweaking the maximum thread pool size for Jetty, should that be the issue.