### PR TITLE
Reduce metric cardinality

### DIFF
--- a/src/main/java/com/flightstats/hub/config/properties/DatadogMetricsProperties.java
+++ b/src/main/java/com/flightstats/hub/config/properties/DatadogMetricsProperties.java
@@ -28,4 +28,8 @@ public class DatadogMetricsProperties {
     }
 
     public boolean isPrimary() { return propertiesLoader.getProperty("metrics.datadog.primary", true); }
+
+    public String getRequestMetricsToIgnore() {
+        return propertiesLoader.getProperty("metrics.data_dog.request.ignore", "");
+    }
 }

--- a/src/main/java/com/flightstats/hub/filter/MetricsRequestFilter.java
+++ b/src/main/java/com/flightstats/hub/filter/MetricsRequestFilter.java
@@ -76,11 +76,12 @@ public class MetricsRequestFilter implements ContainerRequestFilter, ContainerRe
                 log.info("call to shutdown, ignoring statsd time {}", time);
             } else {
                 String[] tagArray = getTagArray(tags);
-                if (!statsdFilter.isTestChannel(channel)) {
+                String metric = isInternal
+                        ? ( isChannel ? "internal.channel" : "internal.nonchannel" )
+                        : ( isChannel ? "api.channel" : "api.nonchannel" );
+
+                if (!statsdFilter.isTestChannel(channel) && !statsdFilter.isIgnoredRequestMetric(metric)) {
                     log.trace("statsdReporter data sent: {}", Arrays.toString(tagArray));
-                    String metric = isInternal
-                            ? ( isChannel ? "internal.channel" : "internal.nonchannel" )
-                            : ( isChannel ? "api.channel" : "api.nonchannel" );
                     statsdReporter.time("request." + metric, requestState.getStart(), tagArray);
                 }
             }

--- a/src/main/java/com/flightstats/hub/filter/MetricsRequestFilter.java
+++ b/src/main/java/com/flightstats/hub/filter/MetricsRequestFilter.java
@@ -61,9 +61,11 @@ public class MetricsRequestFilter implements ContainerRequestFilter, ContainerRe
             if (!isBlank(channel)) {
                 tags.put("channel", channel);
             }
-            String tag = RequestUtils.getTag(request);
-            if (!isBlank(tag)) {
-                tags.put("tag", tag);
+            else {
+                String tag = RequestUtils.getTag(request);
+                if (!isBlank(tag)) {
+                    tags.put("channel", "tag/" + tag);
+                }
             }
 
             if (isBlank(endpoint)) {

--- a/src/main/java/com/flightstats/hub/metrics/StatsdReporter.java
+++ b/src/main/java/com/flightstats/hub/metrics/StatsdReporter.java
@@ -59,10 +59,6 @@ public class StatsdReporter {
         reportWithBothClients(statsDClient -> statsDClient.gauge(name, value, tags));
     }
 
-    public void requestTime(long start, String... tags) {
-        reportWithBothClients((statsDClient) -> statsDClient.time("request", System.currentTimeMillis() - start, tags));
-    }
-
     public void time(String name, long start, String... tags) {
         reportWithBothClients(statsDClient -> statsDClient.time(name, System.currentTimeMillis() - start, tags));
     }

--- a/src/systemTest/java/com/flightstats/hub/system/SystemTestUtils.java
+++ b/src/systemTest/java/com/flightstats/hub/system/SystemTestUtils.java
@@ -1,0 +1,17 @@
+package com.flightstats.hub.system;
+
+import com.flightstats.hub.util.StringUtils;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class SystemTestUtils {
+    public static String randomChannelName() {
+        return randomChannelName(10);
+    }
+
+    public static String randomChannelName(int randomLength) {
+        return "test_"              // channels that begin with test_ are ignored for metrics
+                + "automated_"      // denote it's from an automated system test
+                + StringUtils.randomAlphaNumeric(randomLength);
+    }
+}

--- a/src/systemTest/java/com/flightstats/hub/system/functional/ChannelLatestUpdatedStateTest.java
+++ b/src/systemTest/java/com/flightstats/hub/system/functional/ChannelLatestUpdatedStateTest.java
@@ -13,13 +13,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.concurrent.TimeUnit;
 
-import static com.flightstats.hub.util.StringUtils.randomAlphaNumeric;
+import static com.flightstats.hub.system.SystemTestUtils.randomChannelName;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -39,7 +38,7 @@ class ChannelLatestUpdatedStateTest extends TestSuiteClassWrapper {
 
     @BeforeEach
     void setup() {
-        channelName = randomAlphaNumeric(10);
+        channelName = randomChannelName();
     }
 
     @AfterEach

--- a/src/systemTest/java/com/flightstats/hub/system/functional/ChannelMaxItemsEnforcementTest.java
+++ b/src/systemTest/java/com/flightstats/hub/system/functional/ChannelMaxItemsEnforcementTest.java
@@ -19,13 +19,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import javax.inject.Inject;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static com.flightstats.hub.util.StringUtils.randomAlphaNumeric;
+import static com.flightstats.hub.system.SystemTestUtils.randomChannelName;
 import static org.hamcrest.core.Is.is;
 
 @Execution(ExecutionMode.SAME_THREAD)
@@ -69,7 +68,7 @@ class ChannelMaxItemsEnforcementTest extends TestSuiteClassWrapper {
     }
 
     private void createChannelWithMaxItems(ChannelType type) {
-        channelName = randomAlphaNumeric(10);
+        channelName = randomChannelName();
         ChannelConfig channelConfig = ChannelConfig.builder()
                 .name(channelName)
                 .storage(type.name())

--- a/src/systemTest/java/com/flightstats/hub/system/functional/ChannelReplicationTest.java
+++ b/src/systemTest/java/com/flightstats/hub/system/functional/ChannelReplicationTest.java
@@ -2,9 +2,9 @@ package com.flightstats.hub.system.functional;
 
 import com.flightstats.hub.model.ChannelConfig;
 import com.flightstats.hub.system.extension.TestSuiteClassWrapper;
+import com.flightstats.hub.system.service.ChannelConfigService;
 import com.flightstats.hub.system.service.ChannelItemCreator;
 import com.flightstats.hub.system.service.ChannelItemRetriever;
-import com.flightstats.hub.system.service.ChannelConfigService;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.awaitility.Awaitility;
@@ -17,7 +17,7 @@ import javax.inject.Inject;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
-import static com.flightstats.hub.util.StringUtils.randomAlphaNumeric;
+import static com.flightstats.hub.system.SystemTestUtils.randomChannelName;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Slf4j
@@ -40,8 +40,8 @@ class ChannelReplicationTest extends TestSuiteClassWrapper {
     @BeforeEach
     @SneakyThrows
     void before() {
-        replicationSourceChannelName = randomAlphaNumeric(10) + REPL_SOURCE;
-        replicationDestChannelName = randomAlphaNumeric(10) + REPL_DEST;
+        replicationSourceChannelName = randomChannelName() + REPL_SOURCE;
+        replicationDestChannelName = randomChannelName() + REPL_DEST;
         String replicationSource = channelConfigService.getChannelUrl(replicationSourceChannelName);
         ChannelConfig destination = ChannelConfig.builder()
                 .name(replicationDestChannelName)

--- a/src/systemTest/java/com/flightstats/hub/system/functional/DirectionalQueriesTest.java
+++ b/src/systemTest/java/com/flightstats/hub/system/functional/DirectionalQueriesTest.java
@@ -4,9 +4,9 @@ import com.flightstats.hub.model.ChannelConfig;
 import com.flightstats.hub.model.ChannelItemWithBody;
 import com.flightstats.hub.model.TimeQueryResult;
 import com.flightstats.hub.system.extension.TestSuiteClassWrapper;
+import com.flightstats.hub.system.service.ChannelConfigService;
 import com.flightstats.hub.system.service.ChannelItemCreator;
 import com.flightstats.hub.system.service.ChannelItemRetriever;
-import com.flightstats.hub.system.service.ChannelConfigService;
 import com.google.common.collect.Lists;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.AfterAll;
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.SortedSet;
@@ -23,7 +22,7 @@ import java.util.stream.IntStream;
 
 import static com.flightstats.hub.model.ChannelItemQueryDirection.next;
 import static com.flightstats.hub.model.ChannelItemQueryDirection.previous;
-import static com.flightstats.hub.util.StringUtils.randomAlphaNumeric;
+import static com.flightstats.hub.system.SystemTestUtils.randomChannelName;
 import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -40,7 +39,7 @@ class DirectionalQueriesTest extends TestSuiteClassWrapper {
 
     @BeforeAll
     void before() {
-        historicalChannelName = randomAlphaNumeric(10);
+        historicalChannelName = randomChannelName();
         ChannelConfig config = ChannelConfig.builder()
                 .name(historicalChannelName)
                 .mutableTime(mutableTimeEnd)

--- a/src/systemTest/java/com/flightstats/hub/system/functional/StorageTest.java
+++ b/src/systemTest/java/com/flightstats/hub/system/functional/StorageTest.java
@@ -3,8 +3,8 @@ package com.flightstats.hub.system.functional;
 import com.flightstats.hub.model.ChannelConfig;
 import com.flightstats.hub.model.ChannelType;
 import com.flightstats.hub.system.extension.TestSuiteClassWrapper;
-import com.flightstats.hub.system.service.ChannelItemCreator;
 import com.flightstats.hub.system.service.ChannelConfigService;
+import com.flightstats.hub.system.service.ChannelItemCreator;
 import com.flightstats.hub.system.service.ChannelItemRetriever;
 import com.flightstats.hub.system.service.S3Service;
 import lombok.extern.slf4j.Slf4j;
@@ -17,7 +17,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 import javax.inject.Inject;
 
-import static com.flightstats.hub.util.StringUtils.randomAlphaNumeric;
+import static com.flightstats.hub.system.SystemTestUtils.randomChannelName;
 
 @Slf4j
 class StorageTest extends TestSuiteClassWrapper {
@@ -35,14 +35,14 @@ class StorageTest extends TestSuiteClassWrapper {
 
     @BeforeEach
     void setup() {
-        channelName = randomAlphaNumeric(10);
+        channelName = randomChannelName();
     }
 
     private void createAndAddItemsToChannel(ChannelType type) {
         Awaitility.await().pollInterval(Duration.FIVE_HUNDRED_MILLISECONDS)
                 .atMost(Duration.FIVE_SECONDS)
                 .until(() -> {
-                    channelName = randomAlphaNumeric(10);
+                    channelName = randomChannelName();
                     ChannelConfig channel = ChannelConfig.builder()
                             .name(channelName)
                             .storage(type.toString()).build();

--- a/src/systemTest/java/com/flightstats/hub/system/functional/TimedWebhooksTest.java
+++ b/src/systemTest/java/com/flightstats/hub/system/functional/TimedWebhooksTest.java
@@ -6,8 +6,8 @@ import com.flightstats.hub.model.WebhookType;
 import com.flightstats.hub.system.ModelBuilder;
 import com.flightstats.hub.system.extension.TestSuiteClassWrapper;
 import com.flightstats.hub.system.service.CallbackService;
-import com.flightstats.hub.system.service.ChannelItemCreator;
 import com.flightstats.hub.system.service.ChannelConfigService;
+import com.flightstats.hub.system.service.ChannelItemCreator;
 import com.flightstats.hub.system.service.WebhookService;
 import lombok.extern.slf4j.Slf4j;
 import org.awaitility.Awaitility;
@@ -17,14 +17,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import javax.inject.Inject;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import static com.flightstats.hub.util.StringUtils.randomAlphaNumeric;
-import static java.util.stream.Collectors.toList;
+import static com.flightstats.hub.system.SystemTestUtils.randomChannelName;
 import static junit.framework.Assert.assertTrue;
 
 @Slf4j
@@ -59,8 +57,8 @@ class TimedWebhooksTest extends TestSuiteClassWrapper {
     private boolean channelAndWebhookFactory(WebhookType type) {
         try {
             for (int i = 0; i < CHANNEL_COUNT; i++) {
-                String channelName = randomAlphaNumeric(10);
-                String webhookName = randomAlphaNumeric(10);
+                String channelName = randomChannelName();
+                String webhookName = randomChannelName();
                 channelConfigService.createWithDefaults(channelName);
                 Webhook webhook = modelBuilder
                         .webhookBuilder()

--- a/src/systemTest/java/com/flightstats/hub/system/functional/WebhookErrorTest.java
+++ b/src/systemTest/java/com/flightstats/hub/system/functional/WebhookErrorTest.java
@@ -1,14 +1,12 @@
 package com.flightstats.hub.system.functional;
 
 import com.flightstats.hub.model.Webhook;
-import javax.inject.Inject;
-
 import com.flightstats.hub.model.WebhookCallbackSetting;
 import com.flightstats.hub.system.ModelBuilder;
 import com.flightstats.hub.system.extension.TestSuiteClassWrapper;
 import com.flightstats.hub.system.service.CallbackService;
-import com.flightstats.hub.system.service.ChannelItemCreator;
 import com.flightstats.hub.system.service.ChannelConfigService;
+import com.flightstats.hub.system.service.ChannelItemCreator;
 import com.flightstats.hub.system.service.WebhookService;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -21,9 +19,10 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
+import javax.inject.Inject;
 import java.util.Collections;
 
-import static com.flightstats.hub.util.StringUtils.randomAlphaNumeric;
+import static com.flightstats.hub.system.SystemTestUtils.randomChannelName;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Slf4j
@@ -47,7 +46,7 @@ class WebhookErrorTest extends TestSuiteClassWrapper {
 
     @BeforeAll
     void hubSetup() {
-        nameSeed = randomAlphaNumeric(5);
+        nameSeed = randomChannelName(5);
     }
 
     @BeforeEach

--- a/src/systemTest/java/com/flightstats/hub/system/functional/WebhookLifecycleTest.java
+++ b/src/systemTest/java/com/flightstats/hub/system/functional/WebhookLifecycleTest.java
@@ -5,8 +5,8 @@ import com.flightstats.hub.model.Webhook;
 import com.flightstats.hub.system.ModelBuilder;
 import com.flightstats.hub.system.extension.TestSuiteClassWrapper;
 import com.flightstats.hub.system.service.CallbackService;
-import com.flightstats.hub.system.service.ChannelItemCreator;
 import com.flightstats.hub.system.service.ChannelConfigService;
+import com.flightstats.hub.system.service.ChannelItemCreator;
 import com.flightstats.hub.system.service.WebhookService;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -17,10 +17,10 @@ import org.junit.jupiter.api.Test;
 import javax.inject.Inject;
 import java.util.List;
 
-import static com.flightstats.hub.util.StringUtils.randomAlphaNumeric;
+import static com.flightstats.hub.system.SystemTestUtils.randomChannelName;
 import static java.util.stream.Collectors.toList;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static junit.framework.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Slf4j
 class WebhookLifecycleTest extends TestSuiteClassWrapper {
@@ -40,8 +40,8 @@ class WebhookLifecycleTest extends TestSuiteClassWrapper {
 
     @BeforeEach
     void before() {
-        this.channelName = randomAlphaNumeric(10);
-        this.webhookName = randomAlphaNumeric(10);
+        this.channelName = randomChannelName();
+        this.webhookName = randomChannelName();
     }
 
     private Webhook buildWebhook() {

--- a/src/systemTest/java/com/flightstats/hub/system/functional/WebhookPauseTest.java
+++ b/src/systemTest/java/com/flightstats/hub/system/functional/WebhookPauseTest.java
@@ -4,10 +4,10 @@ import com.flightstats.hub.model.ChannelItemWithBody;
 import com.flightstats.hub.model.Webhook;
 import com.flightstats.hub.model.WebhookType;
 import com.flightstats.hub.system.ModelBuilder;
-import com.flightstats.hub.system.service.ChannelConfigService;
-import com.flightstats.hub.system.service.ChannelItemCreator;
 import com.flightstats.hub.system.extension.TestSuiteClassWrapper;
 import com.flightstats.hub.system.service.CallbackService;
+import com.flightstats.hub.system.service.ChannelConfigService;
+import com.flightstats.hub.system.service.ChannelItemCreator;
 import com.flightstats.hub.system.service.WebhookService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,10 +15,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import javax.inject.Inject;
-
 import java.util.List;
 
-import static com.flightstats.hub.util.StringUtils.randomAlphaNumeric;
+import static com.flightstats.hub.system.SystemTestUtils.randomChannelName;
 import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -63,8 +62,8 @@ class WebhookPauseTest extends TestSuiteClassWrapper {
 
     @BeforeEach
     void setup() {
-        channelName = randomAlphaNumeric(10);
-        webhookName = randomAlphaNumeric(10);
+        channelName = randomChannelName();
+        webhookName = randomChannelName();
         channelConfigService.createWithDefaults(channelName);
     }
 

--- a/src/systemTest/java/com/flightstats/hub/system/service/ChannelItemCreator.java
+++ b/src/systemTest/java/com/flightstats/hub/system/service/ChannelItemCreator.java
@@ -15,7 +15,6 @@ import retrofit2.Call;
 import retrofit2.Response;
 
 import javax.inject.Inject;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;

--- a/src/test/javascript/lib/helpers/random-values.js
+++ b/src/test/javascript/lib/helpers/random-values.js
@@ -1,6 +1,6 @@
 const DEFAULT_LIMIT = 60 * 1000;
 
-const randomChannelName = () => `TeSt_${Math.random().toString().replace(".", "_")}`;
+const randomChannelName = () => `test_automatedjs_${Math.random().toString().replace(".", "_")}`;
 
 const alpha = 'abcdefghijklmnopqrstuvwxyz';
 

--- a/src/test/javascript/lib/utils.js
+++ b/src/test/javascript/lib/utils.js
@@ -17,7 +17,7 @@ Promise.prototype.finally = function (callback) {
 };
 
 exports.randomChannelName = function randomChannelName() {
-    return "TeSt_" + Math.random().toString().replace(".", "_");
+    return "test_automatedjs_" + Math.random().toString().replace(".", "_");
 };
 
 exports.randomNumberBetweenInclusive = function randomNumberBetweenInclusive(min, max) {

--- a/src/test/javascript/scripts/delete_objects.js
+++ b/src/test/javascript/scripts/delete_objects.js
@@ -10,7 +10,7 @@ let request = require('request');
  */
 
 let hubURL = process.argv[2] || 'hub.dls.dev.flightstats.io';
-let namePrefix = process.argv[3] || 'TeSt_0_';
+let namePrefix = process.argv[3] || 'test_automatedjs_0_';
 let objectType = process.argv[4] || 'channel';
 let objectTypePlural = `${objectType}s`;
 


### PR DESCRIPTION
Takes the monolithic `hub.request` metric and splits it into four different metrics:

* `hub.request.api.channel`: all exposed api hub calls that work with channels
* `hub.request.api.nonchannel`: all exposed api hub calls that work on things that don't have channels (webhooks, "gui" interaction, etc)
* `hub.request.internal.channel`: all internal api calls that work with channels (spoke store stuff, mostly)
* `hub.request.internal.nonchannel`: all other internal api magic

I wasn't able to get tests running on my local workstation, so there aren't tests here 😦 That being said, this is a hard thing to test.