### PR TITLE
Bump version of apache.commons to 1.10.0 in response to CVE-2022-42889

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,7 +138,7 @@ dependencies {
     }
 
     compile 'org.apache.commons:commons-lang3:3.7'
-    compile group: 'org.apache.commons', name: 'commons-text', version: '1.2'
+    compile group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
     compile 'commons-io:commons-io:2.6'
     compile('com.github.rholder:guava-retrying:2.0.0') {
         exclude group: 'com.google.guava'


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2022-42889

Per Apache, our code shouldn't be affected:
> On 2022-10-13, the Apache Commons Text team disclosed CVE-2022-42889 . Key takeaways:
> - If you rely on software that uses a version of commons-text prior to 1.10.0, you are likely still not vulnerable: only if this software uses the StringSubstitutor API without properly sanitizing any untrusted input.
> - If your own software uses commons-text, double-check whether it uses the StringSubstitutor API without properly sanitizing any untrusted input. If so, an update to 1.10.0 could be a quick workaround, but the recommended solution is to also properly validate and sanitize any untrusted input.