### PR TITLE
Remove some metrics that we probably don't need

### DIFF
--- a/src/main/java/com/flightstats/hub/channel/ChannelContentResource.java
+++ b/src/main/java/com/flightstats/hub/channel/ChannelContentResource.java
@@ -428,7 +428,6 @@ public class ChannelContentResource {
 
         builder.header("X-Item-Length", itemLength);
 
-        statsdReporter.time(channel, "get", start);
         return builder.build();
     }
 

--- a/src/main/java/com/flightstats/hub/dao/aws/S3BatchContentDao.java
+++ b/src/main/java/com/flightstats/hub/dao/aws/S3BatchContentDao.java
@@ -361,9 +361,7 @@ public class S3BatchContentDao implements ContentDao {
     private SortedSet<MinutePath> listMinutePaths(String channel, ListObjectsRequest request, Traces traces, boolean iterate) {
         SortedSet<MinutePath> paths = new TreeSet<>();
         traces.add("S3BatchContentDao.listMinutePaths ", request.getPrefix(), request.getMarker(), iterate);
-        long start = System.currentTimeMillis();
         ObjectListing listing = s3Client.listObjects(request);
-        statsdReporter.time(channel, "s3.list", start, "type:batch");
         List<S3ObjectSummary> summaries = listing.getObjectSummaries();
         for (S3ObjectSummary summary : summaries) {
             String key = summary.getKey();

--- a/src/main/java/com/flightstats/hub/dao/aws/S3SingleContentDao.java
+++ b/src/main/java/com/flightstats/hub/dao/aws/S3SingleContentDao.java
@@ -232,10 +232,7 @@ public class S3SingleContentDao implements ContentDao {
     }
 
     private ObjectListing getObjectListing(ListObjectsRequest request, String channel) {
-        long start = System.currentTimeMillis();
-        ObjectListing objects = s3Client.listObjects(request);
-        statsdReporter.time(channel, "s3.list", start, "type:single");
-        return objects;
+        return s3Client.listObjects(request);
     }
 
     private boolean shouldContinue(int maxItems, ContentKey limitKey, SortedSet<ContentKey> keys, ObjectListing listing, ContentKey marker) {

--- a/src/main/java/com/flightstats/hub/spoke/SpokeManager.java
+++ b/src/main/java/com/flightstats/hub/spoke/SpokeManager.java
@@ -161,9 +161,6 @@ public class SpokeManager implements SpokeClusterHealthCheck, SpokeChronologySto
                         response = write_client.resource(uri).put(ClientResponse.class, payload);
                         traces.add(server, response.getEntity(String.class));
                         if (response.getStatus() == 201) {
-                            if (firstComplete.compareAndSet(false, true)) {
-                                statsdReporter.time(channel, "heisenberg", traces.getStart());
-                            }
                             quorumLatch.countDown();
                             log.trace("server {} path {} response {}", server, path, response);
                         } else {
@@ -185,7 +182,6 @@ public class SpokeManager implements SpokeClusterHealthCheck, SpokeChronologySto
         } catch (InterruptedException e) {
             throw new RuntimeInterruptedException(e);
         }
-        statsdReporter.time(channel, "consistent", traces.getStart());
         return quorumLatch.getCount() != quorum;
     }
 


### PR DESCRIPTION
This deletes:

`hub.get` -- which logs the time taken any time someone requests a single object using a full object key
`s3.list` -- metrics around how long and often we do lists against S3. This might be useful, but out of all the s3 actions, probably the least
`heisenberg` -- best I can tell is that it's the amount of time it takes for other nodes to respond that they've successfully stored an item in their spoke
`consistent` -- related to `heisenberg`, it's the time it takes for an item to have propagated to a quorum of hub node spokes

the only one of these that I ever look at is `s3.list`, but I don't think it's ever helped me solve a production issue...? If folks feel like it'd be good to keep around, I can remove that change.
