### PR TITLE
Fix lifecycle enforcement and add status resource

### DIFF
--- a/src/main/java/com/flightstats/hub/app/InternalResource.java
+++ b/src/main/java/com/flightstats/hub/app/InternalResource.java
@@ -24,6 +24,7 @@ import static com.flightstats.hub.constant.InternalResourceDescription.TIME_DESC
 import static com.flightstats.hub.constant.InternalResourceDescription.TRACES_DESCRIPTION;
 import static com.flightstats.hub.constant.InternalResourceDescription.WEBHOOK_DESCRIPTION;
 import static com.flightstats.hub.constant.InternalResourceDescription.ZOOKEEPER_DESCRIPTION;
+import static com.flightstats.hub.constant.InternalResourceDescription.S3MM_DESCRIPTION;
 
 @Path("/internal")
 public class InternalResource {
@@ -55,6 +56,7 @@ public class InternalResource {
         addLink("deploy", DEPLOY_DESCRIPTION);
         addLink("health", HEALTH_DESCRIPTION);
         addLink("properties", PROPERTIES_DESCRIPTION);
+        addLink("s3Maintenance", S3MM_DESCRIPTION);
         addLink("shutdown", SHUTDOWN_DESCRIPTION);
         addLink("stacktrace", STACKTRACE_DESCRIPTION);
         addLink("time", TIME_DESCRIPTION);

--- a/src/main/java/com/flightstats/hub/app/InternalS3MaintenanceManagerResource.java
+++ b/src/main/java/com/flightstats/hub/app/InternalS3MaintenanceManagerResource.java
@@ -51,7 +51,7 @@ public class InternalS3MaintenanceManagerResource {
 
     @GET
     @Produces({MediaType.APPLICATION_JSON})
-    public Response getTraces() {
+    public Response getS3MaintenanceManagerResource() {
         ObjectNode root = objectMapper.createObjectNode();
 
         root.put("description", S3MM_DESCRIPTION);

--- a/src/main/java/com/flightstats/hub/app/InternalS3MaintenanceManagerResource.java
+++ b/src/main/java/com/flightstats/hub/app/InternalS3MaintenanceManagerResource.java
@@ -1,0 +1,110 @@
+package com.flightstats.hub.app;
+
+import com.amazonaws.services.s3.model.BucketLifecycleConfiguration;
+import com.amazonaws.services.s3.model.lifecycle.LifecycleFilter;
+import com.amazonaws.services.s3.model.lifecycle.LifecyclePrefixPredicate;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.flightstats.hub.config.properties.PropertiesLoader;
+import com.flightstats.hub.dao.aws.S3MaintenanceManager;
+import com.flightstats.hub.metrics.InternalTracesResource;
+import com.flightstats.hub.util.SecretFilter;
+import com.flightstats.hub.util.TimeUtil;
+import com.google.inject.name.Named;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.TreeSet;
+
+import static com.flightstats.hub.constant.InternalResourceDescription.S3MM_DESCRIPTION;
+import static com.flightstats.hub.constant.InternalResourceDescription.TIME_DESCRIPTION;
+
+@Slf4j
+@Path("/internal/s3Maintenance")
+public class InternalS3MaintenanceManagerResource {
+
+    private final S3MaintenanceManager s3MaintenanceManager;
+    private final S3MaintenanceManager drS3MaintenanceManager;
+    private final ObjectMapper objectMapper;
+
+    @Context
+    private UriInfo uriInfo;
+
+    @Inject
+    public InternalS3MaintenanceManagerResource(@Named("MAIN") S3MaintenanceManager s3MaintenanceManager,
+                                                @Named("DISASTER_RECOVERY") S3MaintenanceManager drS3MaintenanceManager,
+                                                ObjectMapper objectMapper) {
+        this.s3MaintenanceManager = s3MaintenanceManager;
+        this.drS3MaintenanceManager = drS3MaintenanceManager;
+        this.objectMapper = objectMapper;
+    }
+
+    @GET
+    @Produces({MediaType.APPLICATION_JSON})
+    public Response getTraces() {
+        ObjectNode root = objectMapper.createObjectNode();
+
+        root.put("description", S3MM_DESCRIPTION);
+        root.put("details", "Introspect into the last enforcement of lifecycle rules");
+
+        final ObjectNode links = root.putObject("_links");
+        String uri = uriInfo.getRequestUri().toString();
+        addLink(links, "self", uri);
+        addLink(links, "main", uri + "/main");
+        addLink(links, "dr", uri + "/dr");
+
+        return Response.ok(root).build();
+    }
+
+    private void addLink(ObjectNode node, String key, String value) {
+        final ObjectNode link = node.putObject(key);
+        link.put("href", value);
+    }
+
+    @GET
+    @Path("/main")
+    public Response getMain() {
+        return describe(s3MaintenanceManager.getLastLifecycleApplied());
+    }
+
+    @GET
+    @Path("/dr")
+    public Response getDr() {
+        return describe(drS3MaintenanceManager.getLastLifecycleApplied());
+    }
+
+    private Response describe(S3MaintenanceManager.HubS3LifecycleRequest lifecycleRequest) {
+        ObjectNode root = objectMapper.createObjectNode();
+        root.put("lastRequestPresent", null != lifecycleRequest);
+        if (lifecycleRequest == null) {
+            return Response.ok(root).build();
+        }
+
+        root.put("applyDateTime", lifecycleRequest.getRequestTime().toString());
+        root.put("bucket", lifecycleRequest.getRequest().getBucketName());
+        ArrayNode rules = root.putArray("rules");
+        for (BucketLifecycleConfiguration.Rule rule : lifecycleRequest.getRequest().getLifecycleConfiguration().getRules()) {
+            ObjectNode aRule = rules.addObject();
+            aRule.put("id", rule.getId());
+            aRule.put("days", rule.getExpirationInDays());
+            aRule.put("prefix", Optional.ofNullable(rule.getFilter())
+                    .map(LifecycleFilter::getPredicate)
+                    .filter(x -> x instanceof LifecyclePrefixPredicate)
+                    .map(x -> (LifecyclePrefixPredicate) x)
+                    .map(LifecyclePrefixPredicate::getPrefix)
+                    .orElse(null));
+        }
+
+        return Response.ok(root).build();
+    }
+}

--- a/src/main/java/com/flightstats/hub/app/InternalS3MaintenanceManagerResource.java
+++ b/src/main/java/com/flightstats/hub/app/InternalS3MaintenanceManagerResource.java
@@ -72,12 +72,14 @@ public class InternalS3MaintenanceManagerResource {
     }
 
     @GET
+    @Produces({MediaType.APPLICATION_JSON})
     @Path("/main")
     public Response getMain() {
         return describe(s3MaintenanceManager.getLastLifecycleApplied());
     }
 
     @GET
+    @Produces({MediaType.APPLICATION_JSON})
     @Path("/dr")
     public Response getDr() {
         return describe(drS3MaintenanceManager.getLastLifecycleApplied());

--- a/src/main/java/com/flightstats/hub/constant/InternalResourceDescription.java
+++ b/src/main/java/com/flightstats/hub/constant/InternalResourceDescription.java
@@ -8,6 +8,7 @@ public class InternalResourceDescription {
     public static final String HEALTH_DESCRIPTION = "See status of all hubs in a cluster.";
     public static final String PROPERTIES_DESCRIPTION = "Get hub properties with links to other hubs in the cluster.";
     public static final String SHUTDOWN_DESCRIPTION = "See if any server is being shutdown, shutdown a node, and reset the shutdown lock.";
+    public static final String S3MM_DESCRIPTION = "Introspect into S3 lifecycle rule maintenance.";
     public static final String STACKTRACE_DESCRIPTION = "Get a condensed stacktrace with links to other hubs in the cluster.";
     public static final String TIME_DESCRIPTION = "Links for managing time in a hub cluster.";
     public static final String TRACES_DESCRIPTION = "Shows active requests, the slowest 100, and the latest 100 with links to other hubs in the cluster";


### PR DESCRIPTION
The [previous PR](https://github.com/flightstats/hub/pull/1334/files#diff-7f3494937fba6d318fe71fe475537b0e7a5f8b7ac1e9b51e09b7e4e43c5d265aL75) added a bug in which `@Singleton` annotated resources are lazily loaded. Since they were never referenced, they were never instantiated.

This fixes that problem by... instantiating them in an internal resource (`/internal/s3Maintenance`) and adding the ability to interrogate the last rules set.