### PR TITLE
Refactor HubS3Client, removing bucketName

### DIFF
--- a/src/main/java/com/flightstats/hub/config/binding/ClusterHubBindings.java
+++ b/src/main/java/com/flightstats/hub/config/binding/ClusterHubBindings.java
@@ -156,14 +156,15 @@ public class ClusterHubBindings extends AbstractModule {
     @Singleton
     @Named("MAIN")
     public HubS3Client getHubS3Client(S3Properties s3Properties, @Named("MAIN") AmazonS3 s3Client, StatsdReporter statsdReporter) {
-        return new HubS3Client(s3Properties, s3Client, statsdReporter);
+        HubS3Client.performUglyLegacySanityCheckOnBucketName(s3Client, s3Properties.getBucketName());
+        return new HubS3Client(s3Client, statsdReporter);
     }
 
     @Provides
     @Singleton
     @Named("DISASTER_RECOVERY")
-    public HubS3Client getDisasterRecoveryHubS3Client(S3Properties s3Properties, @Named("DISASTER_RECOVERY") AmazonS3 s3Client, StatsdReporter statsdReporter) {
-        return new HubS3Client(s3Properties, s3Client, statsdReporter);
+    public HubS3Client getDisasterRecoveryHubS3Client(@Named("DISASTER_RECOVERY") AmazonS3 s3Client, StatsdReporter statsdReporter) {
+        return new HubS3Client(s3Client, statsdReporter);
     }
 
     @Singleton

--- a/src/main/java/com/flightstats/hub/config/binding/SingleHubBindings.java
+++ b/src/main/java/com/flightstats/hub/config/binding/SingleHubBindings.java
@@ -84,14 +84,15 @@ public class SingleHubBindings extends AbstractModule {
     @Singleton
     @Named("MAIN")
     public HubS3Client getHubS3Client(S3Properties s3Properties, @Named("MAIN") AmazonS3 s3Client, StatsdReporter statsdReporter) {
-        return new HubS3Client(s3Properties, s3Client, statsdReporter);
+        HubS3Client.performUglyLegacySanityCheckOnBucketName(s3Client, s3Properties.getBucketName());
+        return new HubS3Client(s3Client, statsdReporter);
     }
 
     @Provides
     @Singleton
     @Named("DISASTER_RECOVERY")
-    public HubS3Client getDisasterRecoveryHubS3Client(S3Properties s3Properties, @Named("DISASTER_RECOVERY") AmazonS3 s3Client, StatsdReporter statsdReporter) {
-        return new HubS3Client(s3Properties, s3Client, statsdReporter);
+    public HubS3Client getDisasterRecoveryHubS3Client(@Named("DISASTER_RECOVERY") AmazonS3 s3Client, StatsdReporter statsdReporter) {
+        return new HubS3Client(s3Client, statsdReporter);
     }
 
     @Singleton

--- a/src/main/java/com/flightstats/hub/dao/ContentDao.java
+++ b/src/main/java/com/flightstats/hub/dao/ContentDao.java
@@ -32,7 +32,9 @@ public interface ContentDao {
 
     void delete(String channelName);
 
-    void initialize();
+    default void initialize() {
+        // do nothing
+    };
 
     Optional<ContentKey> getLatest(String channel, ContentKey limitKey, Traces traces);
 

--- a/src/main/java/com/flightstats/hub/dao/aws/HubS3Client.java
+++ b/src/main/java/com/flightstats/hub/dao/aws/HubS3Client.java
@@ -170,18 +170,18 @@ public class HubS3Client {
         return s3Client.getCachedResponseMetadata(request);
     }
 
-    void countError(String errorBucketName, SdkClientException exception, AmazonWebServiceRequest request, String method, List<String> keys) {
+    void countError(String bucketName, SdkClientException exception, AmazonWebServiceRequest request, String method, List<String> keys) {
         List<String> tags = new ArrayList<>();
         tags.add("exception:" + exception.getClass().getCanonicalName());
         tags.add("method:" + method);
-        tags.add("bucket:" + errorBucketName);
+        tags.add("bucket:" + bucketName);
 
         String requestId = Optional.ofNullable(getCachedResponseMetadata(request))
                 .map(ResponseMetadata::getRequestId)
                 .orElse("unknown");
         String errorMessage = String.format("S3 Error %s for bucket %s and keys: %s. Request ID: %s",
                 method,
-                errorBucketName,
+                bucketName,
                 String.join(", ", keys),
                 requestId);
         log.error(errorMessage, exception);

--- a/src/main/java/com/flightstats/hub/dao/aws/S3BatchContentDao.java
+++ b/src/main/java/com/flightstats/hub/dao/aws/S3BatchContentDao.java
@@ -412,11 +412,6 @@ public class S3BatchContentDao implements ContentDao {
     }
 
     @Override
-    public void initialize() {
-        s3Client.initialize();
-    }
-
-    @Override
     public Optional<ContentKey> getLatest(String channel, ContentKey limitKey, Traces traces) {
         throw new UnsupportedOperationException("use query interface");
     }

--- a/src/main/java/com/flightstats/hub/dao/aws/S3LargeContentDao.java
+++ b/src/main/java/com/flightstats/hub/dao/aws/S3LargeContentDao.java
@@ -78,9 +78,6 @@ public class S3LargeContentDao implements ContentDao {
 
     }
 
-    public void initialize() {
-        s3Client.initialize();
-    }
 
     @Override
     public Optional<ContentKey> getLatest(String channel, ContentKey limitKey, Traces traces) {

--- a/src/main/java/com/flightstats/hub/dao/aws/S3SingleContentDao.java
+++ b/src/main/java/com/flightstats/hub/dao/aws/S3SingleContentDao.java
@@ -89,10 +89,6 @@ public class S3SingleContentDao implements ContentDao {
         return metadata;
     }
 
-    @Override
-    public void initialize() {
-        s3Client.initialize();
-    }
 
     @Override
     public Optional<ContentKey> getLatest(String channel, ContentKey limitKey, Traces traces) {

--- a/src/test/java/com/flightstats/hub/dao/aws/HubS3ClientTest.java
+++ b/src/test/java/com/flightstats/hub/dao/aws/HubS3ClientTest.java
@@ -61,7 +61,6 @@ class HubS3ClientTest {
     void putObject() {
         AmazonS3Client amazonS3Client = mock(AmazonS3Client.class);
         StatsdReporter statsdReporter = mock(StatsdReporter.class);
-        when(s3Properties.getBucketName()).thenReturn("testBucket");
 
         InputStream emptyStream = new ByteArrayInputStream(new byte[0]);
         ObjectMetadata metadata = new ObjectMetadata();

--- a/src/test/java/com/flightstats/hub/dao/aws/HubS3ClientTest.java
+++ b/src/test/java/com/flightstats/hub/dao/aws/HubS3ClientTest.java
@@ -9,7 +9,6 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.flightstats.hub.config.properties.S3Properties;
 import com.flightstats.hub.metrics.StatsdReporter;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -46,9 +45,9 @@ class HubS3ClientTest {
         when(amazonS3Client.getCachedResponseMetadata(request)).thenReturn(s3ResponseMetadata);
         StatsdReporter statsdReporter = mock(StatsdReporter.class);
 
-        HubS3Client hubS3Client = new HubS3Client(s3Properties, amazonS3Client, statsdReporter);
+        HubS3Client hubS3Client = new HubS3Client(amazonS3Client, statsdReporter);
         SdkClientException exception = new AmazonS3Exception("something f'd up");
-        hubS3Client.countError(exception, request, "fauxMethod", Collections.singletonList("foo:bar"));
+        hubS3Client.countError(s3Properties.getBucketName(), exception, request, "fauxMethod", Collections.singletonList("foo:bar"));
 
         verify(statsdReporter).count(
                 "s3.error",
@@ -71,7 +70,7 @@ class HubS3ClientTest {
 
         when(amazonS3Client.putObject(request)).thenThrow(new SdkClientException("testException"));
 
-        HubS3Client hubS3Client = new HubS3Client(s3Properties, amazonS3Client, statsdReporter);
+        HubS3Client hubS3Client = new HubS3Client(amazonS3Client, statsdReporter);
 
 
         try {

--- a/src/test/java/com/flightstats/hub/dao/aws/HubS3ClientTest.java
+++ b/src/test/java/com/flightstats/hub/dao/aws/HubS3ClientTest.java
@@ -38,7 +38,6 @@ class HubS3ClientTest {
     void countError() {
         String requestId = "numbers-and-letters-go-here";
         when(s3ResponseMetadata.getRequestId()).thenReturn(requestId);
-        when(s3Properties.getBucketName()).thenReturn("testBucket");
 
         AmazonS3Client amazonS3Client = mock(AmazonS3Client.class);
         AmazonWebServiceRequest request = mock(AmazonWebServiceRequest.class);
@@ -47,7 +46,7 @@ class HubS3ClientTest {
 
         HubS3Client hubS3Client = new HubS3Client(amazonS3Client, statsdReporter);
         SdkClientException exception = new AmazonS3Exception("something f'd up");
-        hubS3Client.countError(s3Properties.getBucketName(), exception, request, "fauxMethod", Collections.singletonList("foo:bar"));
+        hubS3Client.countError("testBucket", exception, request, "fauxMethod", Collections.singletonList("foo:bar"));
 
         verify(statsdReporter).count(
                 "s3.error",


### PR DESCRIPTION
`bucketName` always referred to the main bucket name, despite it only being used in error messages. Refactor HubS3Client to not hold on to a bucket name, as this leads to invalid and confusing errors when the error
actually happens elsewhere (like the DR bucket).

No functional change expected.