### PR TITLE
HUB-1391: Added Canonical method into SpokeFile.java for 

### DIFF
--- a/src/main/java/com/flightstats/hub/dao/file/SpokeFile.java
+++ b/src/main/java/com/flightstats/hub/dao/file/SpokeFile.java
@@ -32,8 +32,7 @@ class SpokeFile {
 
     boolean write(byte[] bytes, String filename, String path) {
         try {
-            File file = new File(path, filename);
-            FileUtils.writeByteArrayToFile(file, bytes);
+            FileUtils.writeByteArrayToFile(new File(path + filename), bytes);
             return true;
         } catch (IOException e) {
             log.warn("unable to write file " + filename, e);
@@ -78,7 +77,7 @@ class SpokeFile {
         } catch (FileNotFoundException e) {
             log.info("File not found: {} - {}", file.getPath(), e.getMessage());
         } catch (IOException e) {
-            log.warn("Unable to read file: {} - {}", file.getPath(), e.getMessage());
+            log.warn("unable to find for " + file.getName(), e);
         }
         return null;
     }

--- a/src/main/java/com/flightstats/hub/dao/file/SpokeFile.java
+++ b/src/main/java/com/flightstats/hub/dao/file/SpokeFile.java
@@ -32,42 +32,53 @@ class SpokeFile {
 
     boolean write(byte[] bytes, String filename, String path) {
         try {
-            FileUtils.writeByteArrayToFile(new File(path + filename), bytes);
+            File file = new File(path, filename);
+            FileUtils.writeByteArrayToFile(file, bytes);
             return true;
         } catch (IOException e) {
-            log.warn("unable to write file " + filename, e);
+            log.warn("Unable to write file {} at path {}", filename, path, e);
             return false;
         }
     }
 
     <T> T read(String path, String name, Function<String, T> function) {
-        return read(new File(path + name), function);
+        return read(new File(path, name), function);
     }
 
     <T> T read(String path, String name, BiFunction<String, ContentRetriever, T> function) {
-        return read(new File(path + name), function);
+        return read(new File(path, name), function);
     }
 
     private <T> T read(File file, Function<String, T> function) {
+        if (!isSafePath(file)) {
+            log.warn("Potential path traversal attempt: {}", file.getPath());
+            return null;
+        }
+
         try {
             byte[] bytes = FileUtils.readFileToByteArray(file);
             return function.apply(new String(bytes));
         } catch (FileNotFoundException e) {
-            log.warn("file not found {} {} ", file.getName(), e.getMessage());
+            log.warn("File not found: {} - {}", file.getPath(), e.getMessage());
         } catch (IOException e) {
-            log.warn("unable to find for " + file.getName(), e);
+            log.warn("Unable to read file: {} - {}", file.getPath(), e.getMessage());
         }
         return null;
     }
 
     private <T> T read(File file, BiFunction<String, ContentRetriever, T> function) {
+        if (!isSafePath(file)) {
+            log.warn("Potential path traversal attempt: {}", file.getPath());
+            return null;
+        }
+
         try {
             byte[] bytes = FileUtils.readFileToByteArray(file);
             return function.apply(new String(bytes), contentRetriever);
         } catch (FileNotFoundException e) {
-            log.info("file not found {} {} ", file.getName(), e.getMessage());
+            log.info("File not found: {} - {}", file.getPath(), e.getMessage());
         } catch (IOException e) {
-            log.warn("unable to find for " + file.getName(), e);
+            log.warn("Unable to read file: {} - {}", file.getPath(), e.getMessage());
         }
         return null;
     }
@@ -76,10 +87,14 @@ class SpokeFile {
         List<T> list = new ArrayList<>();
         File[] files = new File(path).listFiles();
         if (files == null) {
+            log.warn("No files found at path {}", path);
             return list;
         }
         for (File file : files) {
-            list.add(read(file, function));
+            T item = read(file, function);
+            if (item != null) {
+                list.add(item);
+            }
         }
         return list;
     }
@@ -88,10 +103,14 @@ class SpokeFile {
         List<T> list = new ArrayList<>();
         File[] files = new File(path).listFiles();
         if (files == null) {
+            log.warn("No files found at path {}", path);
             return list;
         }
         for (File file : files) {
-            list.add(read(file, function));
+            T item = read(file, function);
+            if (item != null) {
+                list.add(item);
+            }
         }
         return list;
     }
@@ -100,5 +119,16 @@ class SpokeFile {
         Path path = Paths.get(filepath);
         File file = path.toFile();
         return FileUtils.deleteQuietly(file);
+    }
+
+    private boolean isSafePath(File file) {
+        try {
+            String canonicalPath = file.getCanonicalPath();
+            String canonicalBasePath = new File(".").getCanonicalPath();
+            return canonicalPath.startsWith(canonicalBasePath);
+        } catch (IOException e) {
+            log.warn("Failed to resolve canonical path for {}", file.getPath(), e);
+            return false;
+        }
     }
 }

--- a/src/main/java/com/flightstats/hub/dao/file/SpokeFile.java
+++ b/src/main/java/com/flightstats/hub/dao/file/SpokeFile.java
@@ -36,17 +36,17 @@ class SpokeFile {
             FileUtils.writeByteArrayToFile(file, bytes);
             return true;
         } catch (IOException e) {
-            log.warn("Unable to write file {} at path {}", filename, path, e);
+            log.warn("unable to write file " + filename, e);
             return false;
         }
     }
 
     <T> T read(String path, String name, Function<String, T> function) {
-        return read(new File(path, name), function);
+        return read(new File(path + name), function);
     }
 
     <T> T read(String path, String name, BiFunction<String, ContentRetriever, T> function) {
-        return read(new File(path, name), function);
+        return read(new File(path + name), function);
     }
 
     private <T> T read(File file, Function<String, T> function) {
@@ -59,9 +59,9 @@ class SpokeFile {
             byte[] bytes = FileUtils.readFileToByteArray(file);
             return function.apply(new String(bytes));
         } catch (FileNotFoundException e) {
-            log.warn("File not found: {} - {}", file.getPath(), e.getMessage());
+            log.warn("file not found {} {} ", file.getName(), e.getMessage());
         } catch (IOException e) {
-            log.warn("Unable to read file: {} - {}", file.getPath(), e.getMessage());
+            log.warn("unable to find for " + file.getName(), e);
         }
         return null;
     }
@@ -87,14 +87,10 @@ class SpokeFile {
         List<T> list = new ArrayList<>();
         File[] files = new File(path).listFiles();
         if (files == null) {
-            log.warn("No files found at path {}", path);
             return list;
         }
         for (File file : files) {
-            T item = read(file, function);
-            if (item != null) {
-                list.add(item);
-            }
+            list.add(read(file, function));
         }
         return list;
     }
@@ -103,14 +99,10 @@ class SpokeFile {
         List<T> list = new ArrayList<>();
         File[] files = new File(path).listFiles();
         if (files == null) {
-            log.warn("No files found at path {}", path);
             return list;
         }
         for (File file : files) {
-            T item = read(file, function);
-            if (item != null) {
-                list.add(item);
-            }
+            list.add(read(file, function));
         }
         return list;
     }

--- a/src/main/java/com/flightstats/hub/dao/file/SpokeFile.java
+++ b/src/main/java/com/flightstats/hub/dao/file/SpokeFile.java
@@ -75,7 +75,7 @@ class SpokeFile {
             byte[] bytes = FileUtils.readFileToByteArray(file);
             return function.apply(new String(bytes), contentRetriever);
         } catch (FileNotFoundException e) {
-            log.info("File not found: {} - {}", file.getPath(), e.getMessage());
+            log.info("file not found {} {} ", file.getName(), e.getMessage());
         } catch (IOException e) {
             log.warn("unable to find for " + file.getName(), e);
         }


### PR DESCRIPTION
Jira tickets:
https://cirium.atlassian.net/browse/HUB-1391

other related tickets resolved by this change:
https://cirium.atlassian.net/browse/HUB-1387
https://cirium.atlassian.net/browse/HUB-1388
https://cirium.atlassian.net/browse/HUB-1389
https://cirium.atlassian.net/browse/HUB-1405
https://cirium.atlassian.net/browse/HUB-1408

Integration tests:
https://ddt-jenkins.prod.flightstats.io/job/run-hub-integration-tests-against-cluster/110/console

System tests:
https://ddt-jenkins.prod.flightstats.io/job/run-hub-system-tests/29/

Summary about canonical method used here:
getCanonicalPath() is a built-in method in Java's File class. It returns the canonical (standardized) pathname string of the file object, which is an absolute path with all symbolic links, relative paths, and redundant path elements resolved.

Here's how it works:

Absolute Path: It converts the file path to an absolute path.
Normalization: It removes any . (current directory) and .. (parent directory) references to simplify the path.
Symbolic Links: It resolves any symbolic links in the path.

By using getCanonicalPath(), you can reliably determine the actual path on the filesystem that a File object refers to, making it a useful method for validating and sanitizing file paths to prevent path traversal attacks.

Added isSafePath(File file) method to verify if the resolved canonical path of the file starts with the base directory. This ensures that the path is within the intended directory and prevents path traversal attacks.

