### PR TITLE
HUB-1396 : Added sanitization method to fix JS client privacy violation

### DIFF
--- a/src/test/javascript/continuous/verify_latest_spec.js
+++ b/src/test/javascript/continuous/verify_latest_spec.js
@@ -73,17 +73,18 @@ describe(__filename, function () {
         const iteratorFunc = async (item) => {
             const { name } = item;
             console.log('get latest ', name);
-            // Strip any potential user information from the URL
-                    const sanitizedChannelUrl = `${channelUrl}/${encodeURIComponent(name)}/latest?trace=true`;
-                    const res = await hubClientGet(sanitizedChannelUrl, headers);
+            const url = `${channelUrl}/${name}/latest?trace=true`;
+            const res = await hubClientGet(url, headers);
             const statusCode = getProp('statusCode', res);
             if (statusCode === 404) {
                 item.empty = true;
             } else if (statusCode === 303) {
                 const location = fromObjectPath(['headers', 'location'], res);
+                // Ensure location does not contain sensitive information before logging or processing
+                const sanitizedLocation = location ? encodeURIComponent(location) : 'unknown';
                 const strLength = channelUrl.length + name.length + 2;
-                const latestKey = location.substring(strLength);
-                console.log('latestKey ', latestKey, location);
+                const latestKey = sanitizedLocation.substring(strLength);
+                console.log('latestKey (sanitized) ', latestKey);
                 item.latestKey = latestKey;
             } else {
                 console.log('unexpected result');

--- a/src/test/javascript/continuous/verify_latest_spec.js
+++ b/src/test/javascript/continuous/verify_latest_spec.js
@@ -73,8 +73,9 @@ describe(__filename, function () {
         const iteratorFunc = async (item) => {
             const { name } = item;
             console.log('get latest ', name);
-            const url = `${channelUrl}/${name}/latest?trace=true`;
-            const res = await hubClientGet(url, headers);
+            // Strip any potential user information from the URL
+                    const sanitizedChannelUrl = `${channelUrl}/${encodeURIComponent(name)}/latest?trace=true`;
+                    const res = await hubClientGet(sanitizedChannelUrl, headers);
             const statusCode = getProp('statusCode', res);
             if (statusCode === 404) {
                 item.empty = true;


### PR DESCRIPTION
**Jira:**
https://cirium.atlassian.net/browse/HUB-1396

**Integration tests:**
https://ddt-jenkins.prod.flightstats.io/job/run-hub-integration-tests-against-cluster/116/console

**System tests:**
https://ddt-jenkins.prod.flightstats.io/job/run-hub-system-tests/31/

**Jenkins build:**
https://ddt-jenkins.prod.flightstats.io/job/run-hub-development-integration/177/

**Explanation for changes:**
this is a test file which is writtten in JS.

1.**Sanitize location:**:
Before using or logging the location header, we sanitize it using encodeURIComponent to ensure that no sensitive information is exposed.

2.**Log Sanitized Data Only:**
The latestKey is derived from the sanitized location, and only this sanitized version is logged.

3.**Additional Safety Check:**
Added a check to ensure that location is defined before proceeding with encoding and substring operations.
By implementing these changes, we ensure that the handling of the location header and the extraction of the latestKey are performed securely, mitigating the risk of privacy violations and inadvertent exposure of sensitive data.